### PR TITLE
metadata: mixing rule metadata now used for nb_converter

### DIFF
--- a/eex/metadata/__init__.py
+++ b/eex/metadata/__init__.py
@@ -12,7 +12,7 @@ from .four_body_terms import four_body_metadata
 from .nb_terms import nb_metadata 
 
 # Bring in additional metadata
-from .additional_metadata import box_metadata, exclusions
+from .additional_metadata import box_metadata, exclusions, mixing_rules
 
 # Bring in the helper functions
 from .md_helper import *

--- a/eex/metadata/additional_metadata.py
+++ b/eex/metadata/additional_metadata.py
@@ -141,9 +141,9 @@ _van_der_waals = {
 mixing_rules = ["lorentz_berthelot",
                 "arithmetic",
                 "geometric",
-                "kong",
-                "sixth_power",
-                "custom"]
+                "sixthpower"]
+                # "kong", NYI
+                # "custom"] NYI
 
 _neighbor = {
         "verlet": {

--- a/eex/nb_converter.py
+++ b/eex/nb_converter.py
@@ -2,6 +2,7 @@
 Converts various NB forms to other equivalents. In addtion, programs combining rules
 """
 
+from .metadata import mixing_rules
 
 ## LJ Conversions
 def _LJ_ab_to_ab(coeffs):
@@ -101,6 +102,9 @@ def _lorentz_berthelot(sigma_epsilon_i, sigma_epsilon_j):
 
     return new_params
 
+def _arithmetic(sigma_epsilon_i, sigma_epsilon_j):
+    return _lorentz_berthelot(sigma_epsilon_i, sigma_epsilon_j)
+
 
 def _geometric(sigma_epsilon_i, sigma_epsilon_j):
     new_params = {}
@@ -142,10 +146,11 @@ def mix_LJ(coeff_i, coeff_j, mixing_rule, origin="AB", final="AB"):
 
     return convert_params
 
-LJ_mixing_functions = {
-    "lorentz-berthelot" : _lorentz_berthelot,
-    "arithmetic": _lorentz_berthelot,
-    "geometric" : _geometric,
-    "sixthpower" : _sixthpower,
-    #"kong": _kong,
-}
+# Build mixing rules conversion
+
+LJ_mixing_functions = {}
+
+for mix in mixing_rules:
+    internal_function = "_" + mix
+
+    LJ_mixing_functions[mix] = eval(internal_function)

--- a/eex/tests/test_amber.py
+++ b/eex/tests/test_amber.py
@@ -235,7 +235,7 @@ def test_amber_compatibility_check_mixing_rule(butane_dl):
                               utype={'K': "kcal * mol **-1 * angstrom ** -2",
                                      'R0': "angstrom"})
 
-    dl.set_mixing_rule('lorentz-berthelot')
+    dl.set_mixing_rule('lorentz_berthelot')
 
     eex.translators.amber.write_amber_file(dl, oname)
 

--- a/eex/tests/test_nb.py
+++ b/eex/tests/test_nb.py
@@ -30,14 +30,14 @@ def test_convert_impossible_LJ_coeffs(form, coeffs):
 
 ## Test LJ mixing
 
-@pytest.mark.parametrize("mixing_rule", ["lorentz-berthelot", "geometric", "sixthpower"])
+@pytest.mark.parametrize("mixing_rule", ["lorentz_berthelot", "geometric", "sixthpower"])
 def test_LJ_mixing(mixing_rule):
     coeff1 = {'epsilon': 1, 'sigma': 1}
     coeff2 = {'epsilon': 2, 'sigma': 2}
 
 
     # Expected answers
-    mixed_coeffs = {"lorentz-berthelot": {'epsilon': (2) ** (1./2.), 'sigma': 1.5},
+    mixed_coeffs = {"lorentz_berthelot": {'epsilon': (2) ** (1./2.), 'sigma': 1.5},
                     "geometric": {'epsilon': (2) ** (1./2.), 'sigma': (2) ** (1./2.)},
                     "sixthpower": {'epsilon': (2 ** (1./2.)) / (4), 'sigma': 32. **(1./6.)},
                     }

--- a/eex/translators/amber/amber_metadata.py
+++ b/eex/translators/amber/amber_metadata.py
@@ -178,7 +178,7 @@ forcefield_parameters = {
 }
 
 # Can be either keyword - equivalent
-mixing_rule = ["lorentz-berthelot", "arithmetic"]
+mixing_rule = ["lorentz_berthelot", "arithmetic"]
 
 ## Exclusions and scalings
 


### PR DESCRIPTION
This PR changes the way the LJ_mixing_function dictionary is built in nb_converter. It is now based on EEX metadata.