### PR TITLE
Add functional form converters

### DIFF
--- a/eex/__init__.py
+++ b/eex/__init__.py
@@ -9,7 +9,9 @@ from . import filelayer
 from . import testing
 from . import translators
 from . import utility
+from . import form_converters
 from .units import ureg
+
 
 # Initializes the eex_init metadata
 from . import eex_init

--- a/eex/dihedral_converter.py
+++ b/eex/dihedral_converter.py
@@ -1,0 +1,153 @@
+"""
+Converts various dihedral forms to other equivalents.
+"""
+import numpy as np
+
+
+def _alternating_signs(n):
+    """
+        Return 1 if n is zero
+        Returns -1 if n is odd
+        Returns 1 if n is even
+    """
+
+    if (n < 0.0):
+        raise ValueError("Argument has to be zero or a positive integer")
+
+    return (-1.0) ** n
+
+
+def _cosnx(n):
+    """
+        Converts Cos(n*x) to a polynomial of cosines whose coefficients are given by a
+        Chebyshev polynomial
+    """
+    p = np.polynomial.chebyshev.Chebyshev.basis(n)
+    return p.convert(kind=np.polynomial.Polynomial)
+
+
+def _OPLS_to_RB(coeffs):
+    """
+        RB form: "A_0 + A_1 * (cos(phi)) + A_2 * (cos(phi)) ** 2 + A_3 * (cos(phi)) ** 3 + A_4 * (cos(phi)) ** (4) + A_5 * (cos(phi)) ** (5)"
+
+        opls form:"0.5*K_1*(1+cos(phi)) + 0.5 * K_2 * (1-cos(2*phi)) + 0.5 * K_3 * (1+cos(3*phi)) + 0.5 * K_4 * (1-cos(4*phi))"
+    """
+
+    k_1 = coeffs['K_1']
+    k_2 = coeffs['K_2']
+    k_3 = coeffs['K_3']
+    k_4 = coeffs['K_4']
+
+    if(k_1 == 0.0 and k_2 == 0.0 and k_3 == 0.0 and k_4 == 0.0):
+        raise ValueError('OPLS to RB dihedral conversion not possible. All the coefficients of this dihedral are zero.')
+
+    ret = dict()
+    # Note: c1 and c3 are the negative of what is defined on equation 4.64 of Gromacs Manual 4.6.1
+    ret['A_0'] = k_2 + 0.5 * (k_1 + k_3)
+    ret['A_1'] = 0.5 * (k_1 - 3.0 * k_3)
+    ret['A_2'] = -k_2 + 4.0 * k_4
+    ret['A_3'] = 2.0 * k_3
+    ret['A_4'] = -4.0 * k_4
+    ret['A_5'] = 0.0
+
+    return ret
+
+
+def _RB_to_OPLS(coeffs):
+
+    a_0 = coeffs['A_0']
+    a_1 = coeffs['A_1']
+    a_2 = coeffs['A_2']
+    a_3 = coeffs['A_3']
+    a_4 = coeffs['A_4']
+    a_5 = coeffs['A_5']
+
+    ret = dict()
+
+    if(a_0 == 0.0 and a_1 == 0.0 and a_2 == 0.0 and a_3 == 0.0 and a_4 == 0.0 and a_5 == 0.0):
+        raise ValueError('OPLS to RB dihedral conversion not possible. All the coefficients of this dihedral are zero.')
+
+    if (a_5 != 0.0 and a_1 + a_2 + a_3 + a_4 != 0.0):
+        raise ValueError("RB to OPLS dihedral conversion not possible. This RB dihedral is inconsistent with OPLS style")
+
+    # note - f1 and f3 are opposite sign as expected in GROMACS, probably because of angle conventions.
+    ret['K_1'] = 2.0 * a_1 + 3.0 * a_3 / 2.0
+    ret['K_2'] = -a_2 - a_4
+    ret['K_3'] = a_3 / 2.0
+    ret['K_4'] = -a_4 / 4.0
+    return ret
+
+
+def _CHARMM_to_RB(coeffs):
+
+    ret = dict()
+
+    n = coeffs['n']
+    d = coeffs['d']
+    k = coeffs['K']
+
+    if n > 5:
+        raise ValueError("CHARMM to RB dihedral conversion not possible. The multiplicity value n in the CHARMM dihedral must be less than 5")
+
+    if n < 0:
+        raise ValueError("CHARMM to RB dihedral conversion not possible. The multiplicity must be a positive integer.")
+    # Make sure d is either 0.0, pi, 2pi, 3pi, 4pi.
+    # TODO: Need to generalize for other values of d.
+
+    if n == 0 and d % np.pi == 0:
+        raise ValueError("CHARMM to RB dihedral conversion not possible. The CHARMM dihedral energy is zero.")
+
+    if k == 0:
+        raise ValueError("CHARMM to RB dihedral conversion not possible. The CHARMM dihedral energy is zero.")
+
+    if not np.isclose(d % np.pi, 0.0):
+        raise ValueError("CHARMM to RB dihedral conversion not possible. The CHARMM phase shift d is not a multiple of PI.")
+
+    div = np.abs(d / np.pi)
+    p = list(_alternating_signs(div) * _cosnx(n))
+    ret = dict()
+    ret["A_0"] = 0.0
+    ret["A_1"] = 0.0
+    ret["A_2"] = 0.0
+    ret["A_3"] = 0.0
+    ret["A_4"] = 0.0
+    ret["A_5"] = 0.0
+
+    for i in range(0, len(p)):
+        ret['A_' + str(i)] = p[i] * k
+    ret["A_0"] = ret["A_0"] + k
+    return ret
+
+
+def _RB_to_CHARMM(coeffs):
+
+    a_0 = coeffs['A_0']
+    a_1 = coeffs['A_1']
+    a_2 = coeffs['A_2']
+    a_3 = coeffs['A_3']
+    a_4 = coeffs['A_4']
+    a_5 = coeffs['A_5']
+
+    # TODO probably we need a more robust way of doing this
+    rb_coeffs = np.array([a_0, a_1, a_2, a_3, a_4, a_5])
+
+    if(np.all(rb_coeffs == 0)):
+        raise ValueError('All the coefficients of this dihedral are zero.')
+
+    nz = np.nonzero(rb_coeffs)[0]
+    n = np.max(nz)
+    p = list(_cosnx(n))
+    idx = np.nonzero(rb_coeffs)[0][-1]
+    if idx == 0:
+        k = rb_coeffs[idx] / (p[idx] + 1)
+    else:
+        k = rb_coeffs[idx] / p[idx]
+    ret = dict()
+    ret['n'] = n
+    ret['K'] = np.abs(k)
+    if k < 0.0:
+        ret['d'] = np.pi
+    else:
+        ret['d'] = 0.0
+
+    return ret

--- a/eex/form_converters/__init__.py
+++ b/eex/form_converters/__init__.py
@@ -1,0 +1,1 @@
+from .convert_helper import convert_form

--- a/eex/form_converters/__init__.py
+++ b/eex/form_converters/__init__.py
@@ -1,1 +1,1 @@
-from .convert_helper import convert_form
+from .convert_form import convert_form

--- a/eex/form_converters/angle_converters.py
+++ b/eex/form_converters/angle_converters.py
@@ -2,37 +2,9 @@
 Converts various angle forms to other equivalents.
 """
 import numpy as np
-from ..metadata import three_body_metadata
+from .converter_registry import register_converter
 
 
+@register_converter(order=3)
 def _convert_nothing(coeffs):
     return coeffs
-
-
-# TODO temporary solution, need something better than this
-_angle_conversion_matrix = dict()
-
-for k, v in three_body_metadata['forms'].items():
-    to_canonical = '_' + k + '_to_' + v['canonical_form']
-    from_canonical = '_' + v['canonical_form'] + '_to_' + k
-    try:
-        _angle_conversion_matrix[k] = (v['parameters'], locals()[to_canonical], locals()[from_canonical])
-    except:
-        _angle_conversion_matrix[k] = (v['parameters'], _convert_nothing, _convert_nothing)
-
-
-def convert_angle_coeffs(coeffs, origin, final):
-
-    difference = set([origin, final]) - set(_angle_conversion_matrix.keys())
-    if (difference):
-        raise KeyError("Conversion cannot be made since %s is not in conversion matrix %s" %
-                       (difference, _angle_conversion_matrix.keys()))
-
-    difference = set(coeffs.keys()) - set(_angle_conversion_matrix[origin][0])
-    if (difference):
-        raise KeyError("The key %s in the coefficient dictionary is not in the list of allowed keys %s" %
-                       (difference, _angle_conversion_matrix[origin][0]))
-
-    internal = _angle_conversion_matrix[origin][1](coeffs)
-    external = _angle_conversion_matrix[final][2](internal)
-    return external

--- a/eex/form_converters/angle_converters.py
+++ b/eex/form_converters/angle_converters.py
@@ -1,0 +1,38 @@
+"""
+Converts various angle forms to other equivalents.
+"""
+import numpy as np
+from ..metadata import three_body_metadata
+
+
+def _convert_nothing(coeffs):
+    return coeffs
+
+
+# TODO temporary solution, need something better than this
+_angle_conversion_matrix = dict()
+
+for k, v in three_body_metadata['forms'].items():
+    to_canonical = '_' + k + '_to_' + v['canonical_form']
+    from_canonical = '_' + v['canonical_form'] + '_to_' + k
+    try:
+        _angle_conversion_matrix[k] = (v['parameters'], locals()[to_canonical], locals()[from_canonical])
+    except:
+        _angle_conversion_matrix[k] = (v['parameters'], _convert_nothing, _convert_nothing)
+
+
+def convert_angle_coeffs(coeffs, origin, final):
+
+    difference = set([origin, final]) - set(_angle_conversion_matrix.keys())
+    if (difference):
+        raise KeyError("Conversion cannot be made since %s is not in conversion matrix %s" %
+                       (difference, _angle_conversion_matrix.keys()))
+
+    difference = set(coeffs.keys()) - set(_angle_conversion_matrix[origin][0])
+    if (difference):
+        raise KeyError("The key %s in the coefficient dictionary is not in the list of allowed keys %s" %
+                       (difference, _angle_conversion_matrix[origin][0]))
+
+    internal = _angle_conversion_matrix[origin][1](coeffs)
+    external = _angle_conversion_matrix[final][2](internal)
+    return external

--- a/eex/form_converters/bond_converters.py
+++ b/eex/form_converters/bond_converters.py
@@ -2,37 +2,9 @@
 Converts various bond forms to other equivalents.
 """
 import numpy as np
-from ..metadata import two_body_metadata
+from .converter_registry import register_converter
 
 
+@register_converter(order=2)
 def _convert_nothing(coeffs):
     return coeffs
-
-
-# TODO temporary solution, need something better than this
-_bond_conversion_matrix = dict()
-
-for k, v in two_body_metadata['forms'].items():
-    to_canonical = '_' + k + '_to_' + v['canonical_form']
-    from_canonical = '_' + v['canonical_form'] + '_to_' + k
-    try:
-        _bond_conversion_matrix[k] = (v['parameters'], locals()[to_canonical], locals()[from_canonical])
-    except:
-        _bond_conversion_matrix[k] = (v['parameters'], _convert_nothing, _convert_nothing)
-
-
-def convert_bond_coeffs(coeffs, origin, final):
-
-    difference = set([origin, final]) - set(_bond_conversion_matrix.keys())
-    if (difference):
-        raise KeyError("Conversion cannot be made since %s is not in conversion matrix %s" %
-                       (difference, _bond_conversion_matrix.keys()))
-
-    difference = set(coeffs.keys()) - set(_bond_conversion_matrix[origin][0])
-    if (difference):
-        raise KeyError("The key %s in the coefficient dictionary is not in the list of allowed keys %s" %
-                       (difference, _bond_conversion_matrix[origin][0]))
-
-    internal = _bond_conversion_matrix[origin][1](coeffs)
-    external = _bond_conversion_matrix[final][2](internal)
-    return external

--- a/eex/form_converters/bond_converters.py
+++ b/eex/form_converters/bond_converters.py
@@ -1,0 +1,38 @@
+"""
+Converts various bond forms to other equivalents.
+"""
+import numpy as np
+from ..metadata import two_body_metadata
+
+
+def _convert_nothing(coeffs):
+    return coeffs
+
+
+# TODO temporary solution, need something better than this
+_bond_conversion_matrix = dict()
+
+for k, v in two_body_metadata['forms'].items():
+    to_canonical = '_' + k + '_to_' + v['canonical_form']
+    from_canonical = '_' + v['canonical_form'] + '_to_' + k
+    try:
+        _bond_conversion_matrix[k] = (v['parameters'], locals()[to_canonical], locals()[from_canonical])
+    except:
+        _bond_conversion_matrix[k] = (v['parameters'], _convert_nothing, _convert_nothing)
+
+
+def convert_bond_coeffs(coeffs, origin, final):
+
+    difference = set([origin, final]) - set(_bond_conversion_matrix.keys())
+    if (difference):
+        raise KeyError("Conversion cannot be made since %s is not in conversion matrix %s" %
+                       (difference, _bond_conversion_matrix.keys()))
+
+    difference = set(coeffs.keys()) - set(_bond_conversion_matrix[origin][0])
+    if (difference):
+        raise KeyError("The key %s in the coefficient dictionary is not in the list of allowed keys %s" %
+                       (difference, _bond_conversion_matrix[origin][0]))
+
+    internal = _bond_conversion_matrix[origin][1](coeffs)
+    external = _bond_conversion_matrix[final][2](internal)
+    return external

--- a/eex/form_converters/convert_form.py
+++ b/eex/form_converters/convert_form.py
@@ -1,0 +1,32 @@
+
+"""
+A helper function to access EEX converteres easier
+"""
+from .converter_registry import REGISTERED_CONVERTERS
+from .. import metadata
+from . import dihedral_converters
+from . import angle_converters
+from . import bond_converters
+from .convert_helper import sanitize_term_order_name
+
+
+def convert_form(order, coeffs, origin, final):
+
+    order = sanitize_term_order_name(order)
+
+    term_md = metadata.get_term_metadata(order, "forms")
+
+    # TODO temporary solution
+    to_canonical = '_' + origin + '_to_' + term_md[origin]["canonical_form"]
+    from_canonical = '_' + term_md[final]["canonical_form"] + '_to_' + final
+    if order == 2:
+        ret = convert_bond_coeffs(coeffs, origin, final)
+    elif order == 3:
+        ret = convert_angle_coeffs(coeffs, origin, final)
+    elif order == 4:
+        canonical_coeffs = REGISTERED_CONVERTERS[order][to_canonical](coeffs)
+        ret = REGISTERED_CONVERTERS[order][from_canonical](canonical_coeffs)
+    else:
+        raise KeyError("EEX: Term order %s not recognized." % str(order))
+
+    return ret

--- a/eex/form_converters/convert_helper.py
+++ b/eex/form_converters/convert_helper.py
@@ -1,0 +1,41 @@
+
+"""
+A helper function to access EEX converteres easier
+"""
+
+from .bond_converters import convert_bond_coeffs
+from .angle_converters import convert_angle_coeffs
+from .dihedral_converters import convert_dihedral_coeffs
+
+
+def sanitize_term_order_name(order):
+    if isinstance(order, str):
+        order = order.lower()
+
+    if order in [2, "two", "bond", "bonds"]:
+        return 2
+    elif order in [3, "three", "angle", "angles"]:
+        return 3
+    elif order in [4, "four", "dihedral", "dihedrals"]:
+        return 4
+    else:
+        raise KeyError("EEX: Term order name '%s' not recognized." % str(order))
+
+
+def convert_form(order, coeffs, origin, final):
+    order = sanitize_term_order_name(order)
+
+    if order == 2:
+        ret = convert_bond_coeffs(coeffs, origin, final)
+    elif order == 3:
+        ret = convert_angle_coeffs(coeffs, origin, final)
+    elif order == 4:
+        ret = convert_dihedral_coeffs(coeffs, origin, final)
+    else:
+        raise KeyError("EEX: Term order %s not recognized." % str(order))
+
+    return ret
+    # # Do we have a name?
+    # if name:
+    #     tmpdata = tmpdata[name]
+    # else:

--- a/eex/form_converters/convert_helper.py
+++ b/eex/form_converters/convert_helper.py
@@ -2,10 +2,11 @@
 """
 A helper function to access EEX converteres easier
 """
-
-from .bond_converters import convert_bond_coeffs
-from .angle_converters import convert_angle_coeffs
-from .dihedral_converters import convert_dihedral_coeffs
+from .converter_registry import REGISTERED_CONVERTERS
+from .. import metadata
+from . import dihedral_converters
+from . import angle_converters
+from . import bond_converters
 
 
 def sanitize_term_order_name(order):
@@ -23,14 +24,21 @@ def sanitize_term_order_name(order):
 
 
 def convert_form(order, coeffs, origin, final):
+
     order = sanitize_term_order_name(order)
 
+    term_md = metadata.get_term_metadata(order, "forms")
+
+    # TODO temporary solution
+    to_canonical = '_' + origin + '_to_' + term_md[origin]["canonical_form"]
+    from_canonical = '_' + term_md[final]["canonical_form"] + '_to_' + final
     if order == 2:
         ret = convert_bond_coeffs(coeffs, origin, final)
     elif order == 3:
         ret = convert_angle_coeffs(coeffs, origin, final)
     elif order == 4:
-        ret = convert_dihedral_coeffs(coeffs, origin, final)
+        canonical_coeffs = REGISTERED_CONVERTERS[order][to_canonical](coeffs)
+        ret = REGISTERED_CONVERTERS[order][from_canonical](canonical_coeffs)
     else:
         raise KeyError("EEX: Term order %s not recognized." % str(order))
 
@@ -39,3 +47,32 @@ def convert_form(order, coeffs, origin, final):
     # if name:
     #     tmpdata = tmpdata[name]
     # else:
+
+
+# TODO temporary solution, need something better than this
+# _dihedral_conversion_matrix = dict()
+
+# for k, v in four_body_metadata['forms'].items():
+#     to_canonical = '_' + k + '_to_' + v['canonical_form']
+#     from_canonical = '_' + v['canonical_form'] + '_to_' + k
+#     try:
+#         _dihedral_conversion_matrix[k] = (v['parameters'], locals()[to_canonical], locals()[from_canonical])
+#     except:
+#         _dihedral_conversion_matrix[k] = (v['parameters'], _convert_nothing, _convert_nothing)
+
+
+# def convert_dihedral_coeffs(coeffs, origin, final):
+
+#     difference = set([origin, final]) - set(_dihedral_conversion_matrix.keys())
+#     if (difference):
+#         raise KeyError("Conversion cannot be made since %s is not in conversion matrix %s" %
+#                        (difference, _dihedral_conversion_matrix.keys()))
+
+#     difference = set(coeffs.keys()) - set(_dihedral_conversion_matrix[origin][0])
+#     if (difference):
+#         raise KeyError("The key %s in the coefficient dictionary is not in the list of allowed keys %s" %
+#                        (difference, _dihedral_conversion_matrix[origin][0]))
+
+#     internal = _dihedral_conversion_matrix[origin][1](coeffs)
+#     external = _dihedral_conversion_matrix[final][2](internal)
+#     return external

--- a/eex/form_converters/convert_helper.py
+++ b/eex/form_converters/convert_helper.py
@@ -1,14 +1,3 @@
-
-"""
-A helper function to access EEX converteres easier
-"""
-from .converter_registry import REGISTERED_CONVERTERS
-from .. import metadata
-from . import dihedral_converters
-from . import angle_converters
-from . import bond_converters
-
-
 def sanitize_term_order_name(order):
     if isinstance(order, str):
         order = order.lower()
@@ -21,58 +10,3 @@ def sanitize_term_order_name(order):
         return 4
     else:
         raise KeyError("EEX: Term order name '%s' not recognized." % str(order))
-
-
-def convert_form(order, coeffs, origin, final):
-
-    order = sanitize_term_order_name(order)
-
-    term_md = metadata.get_term_metadata(order, "forms")
-
-    # TODO temporary solution
-    to_canonical = '_' + origin + '_to_' + term_md[origin]["canonical_form"]
-    from_canonical = '_' + term_md[final]["canonical_form"] + '_to_' + final
-    if order == 2:
-        ret = convert_bond_coeffs(coeffs, origin, final)
-    elif order == 3:
-        ret = convert_angle_coeffs(coeffs, origin, final)
-    elif order == 4:
-        canonical_coeffs = REGISTERED_CONVERTERS[order][to_canonical](coeffs)
-        ret = REGISTERED_CONVERTERS[order][from_canonical](canonical_coeffs)
-    else:
-        raise KeyError("EEX: Term order %s not recognized." % str(order))
-
-    return ret
-    # # Do we have a name?
-    # if name:
-    #     tmpdata = tmpdata[name]
-    # else:
-
-
-# TODO temporary solution, need something better than this
-# _dihedral_conversion_matrix = dict()
-
-# for k, v in four_body_metadata['forms'].items():
-#     to_canonical = '_' + k + '_to_' + v['canonical_form']
-#     from_canonical = '_' + v['canonical_form'] + '_to_' + k
-#     try:
-#         _dihedral_conversion_matrix[k] = (v['parameters'], locals()[to_canonical], locals()[from_canonical])
-#     except:
-#         _dihedral_conversion_matrix[k] = (v['parameters'], _convert_nothing, _convert_nothing)
-
-
-# def convert_dihedral_coeffs(coeffs, origin, final):
-
-#     difference = set([origin, final]) - set(_dihedral_conversion_matrix.keys())
-#     if (difference):
-#         raise KeyError("Conversion cannot be made since %s is not in conversion matrix %s" %
-#                        (difference, _dihedral_conversion_matrix.keys()))
-
-#     difference = set(coeffs.keys()) - set(_dihedral_conversion_matrix[origin][0])
-#     if (difference):
-#         raise KeyError("The key %s in the coefficient dictionary is not in the list of allowed keys %s" %
-#                        (difference, _dihedral_conversion_matrix[origin][0]))
-
-#     internal = _dihedral_conversion_matrix[origin][1](coeffs)
-#     external = _dihedral_conversion_matrix[final][2](internal)
-#     return external

--- a/eex/form_converters/converter_registry.py
+++ b/eex/form_converters/converter_registry.py
@@ -1,17 +1,4 @@
-
-def sanitize_term_order_name(order):
-    if isinstance(order, str):
-        order = order.lower()
-
-    if order in [2, "two", "bond", "bonds"]:
-        return 2
-    elif order in [3, "three", "angle", "angles"]:
-        return 3
-    elif order in [4, "four", "dihedral", "dihedrals"]:
-        return 4
-    else:
-        raise KeyError("EEX: Term order name '%s' not recognized." % str(order))
-
+from .convert_helper import sanitize_term_order_name
 
 REGISTERED_CONVERTERS = {}
 

--- a/eex/form_converters/converter_registry.py
+++ b/eex/form_converters/converter_registry.py
@@ -1,0 +1,31 @@
+
+def sanitize_term_order_name(order):
+    if isinstance(order, str):
+        order = order.lower()
+
+    if order in [2, "two", "bond", "bonds"]:
+        return 2
+    elif order in [3, "three", "angle", "angles"]:
+        return 3
+    elif order in [4, "four", "dihedral", "dihedrals"]:
+        return 4
+    else:
+        raise KeyError("EEX: Term order name '%s' not recognized." % str(order))
+
+
+REGISTERED_CONVERTERS = {}
+
+for order in (2, 3, 4):
+    REGISTERED_CONVERTERS[order] = {}
+
+
+def register_converter(order=None):
+    order = sanitize_term_order_name(order)
+
+    def decorator_function(fn):
+        REGISTERED_CONVERTERS[order][fn.__name__] = fn
+
+        def wrapper_function(*args, **kwargs):
+            return fn(*args, **kwargs)
+        return wrapper_function
+    return decorator_function

--- a/eex/metadata/four_body_terms.py
+++ b/eex/metadata/four_body_terms.py
@@ -26,11 +26,12 @@ _four_body_functional_forms = {
             "n": "count",
             "d": "[arcunit]",
         },
-        "description": "This is a charmm dihedral"
+        "description": "This is a charmm dihedral",
+        "canonical_form": "ryckaert_bellemans",
     },
     "multi/harmonic": {
         "form": "A_1 + A_2 * (cos(phi)) + A_3 * (cos(phi)) ** 2 + A_4 * (cos(phi)) ** 3 + A_5 * (cos(phi)) ** (4)",
-        "parameters": ["A_1","A_2","A_3", "A_4", "A_5"],
+        "parameters": ["A_1", "A_2", "A_3", "A_4", "A_5"],
         "units": {
             "A_1": "[energy]",
             "A_2": "[energy]",
@@ -38,11 +39,12 @@ _four_body_functional_forms = {
             "A_4": "[energy]",
             "A_5": "[energy]",
         },
-        "description": "This is a multi/harmonic dihedral"
+        "description": "This is a multi/harmonic dihedral",
+        "canonical_form": "ryckaert_bellemans",
     },
     "ryckaert_bellemans": {
         "form": "A_0 + A_1 * (cos(phi)) + A_2 * (cos(phi)) ** 2 + A_3 * (cos(phi)) ** 3 + A_4 * (cos(phi)) ** (4) + A_5 * (cos(phi)) ** (5)",
-        "parameters": ["A_0", "A_1","A_2","A_3", "A_4", "A_5"],
+        "parameters": ["A_0", "A_1", "A_2", "A_3", "A_4", "A_5"],
         "units": {
             "A_0": "[energy]",
             "A_1": "[energy]",
@@ -52,7 +54,8 @@ _four_body_functional_forms = {
             "A_5": "[energy]",
 
         },
-        "description": "This is a ryckaert_bellemans"
+        "description": "This is a ryckaert_bellemans",
+        "canonical_form": "ryckaert_bellemans",
     },
     # "fourier": {
     #     "form": "Sum(k_i * (1.0 + cos(n_i * phi - d_i)))",
@@ -72,7 +75,8 @@ _four_body_functional_forms = {
             "n": "phase",  # + / 1
             "d": "count"
         },
-        "description": "A harmonic dihedral"
+        "description": "A harmonic dihedral",
+        "canonical_form": "ryckaert_bellemans",
     },
     "helix": {
         "form": "A*(1-cos(phi)) + B*(1+cos(3*phi)) + C*(1+cos(phi+PI/4))",
@@ -82,7 +86,8 @@ _four_body_functional_forms = {
             "B": "[energy]",
             "C": "[energy]"
         },
-        "description": "This is a helix dihedral"
+        "description": "This is a helix dihedral",
+        "canonical_form": "helix",
     },
     # "nharmonic": {
     #     "form": "Sum( A_n*(cos(phi))**(n-1))",
@@ -102,7 +107,8 @@ _four_body_functional_forms = {
             "K_3": "[energy]",
             "K_4": "[energy]",
         },
-        "description": "This is a opls dihedral"
+        "description": "This is a opls dihedral",
+        "canonical_form": "ryckaert_bellemans",
     },
     "quadratic": {
         "form": "K*(phi-phi0)**2",
@@ -111,7 +117,8 @@ _four_body_functional_forms = {
             "K": "[energy]",
             "phi0": "[arcunit]"
         },
-        "description": "This is a quadratic dihedral"
+        "description": "This is a quadratic dihedral",
+        "canonical_form": "quadratic",
     },
     "restricted": {
         "form": "0.5*K*(cos(phi)-cos(phi0))**2/(sin(phi)**2)",
@@ -119,13 +126,14 @@ _four_body_functional_forms = {
         "units": {
             "K": "[energy]",
             "phi0": "[arcunit]",
-        },  
-        "description": "This is a restricted bending angle found in Gromacs"
-    },  
+        },
+        "description": "This is a restricted bending angle found in Gromacs",
+        "canonical_form": "restricted",
+    },
 
 
 
-    #######IMPROPERS START HERE
+    # IMPROPERS START HERE
     #"class2_improper": {},
     #"hybrid_improper": {},
     #"none_improper": {},
@@ -139,7 +147,8 @@ _four_body_functional_forms = {
             "K": "[energy]",
             "chi0": "[arcunit]"
         },
-        "description": "This is a cossq improper"
+        "description": "This is a cossq improper",
+        "canonical_form": "cossq_improper",
     },
     "cvff_improper": {
         "form": "K*(1+d*cos(n*chi))",
@@ -149,7 +158,8 @@ _four_body_functional_forms = {
             "d": "phase",
             "n": "count"
         },
-        "description": "This is a cvff improper"
+        "description": "This is a cvff improper",
+        "canonical_form": "ryckaert_bellemans",
     },
     "distance_improper": {
         "form": "K_2*r**2+K_4*r**4",
@@ -158,7 +168,8 @@ _four_body_functional_forms = {
             "K_2": "[energy] * [length]**2",
             "K_4": "[energy] * [length]**4",
         },
-        "description": "This is a distance improper"
+        "description": "This is a distance improper",
+        "canonical_form": "ryckaert_bellemans",
     },
     "fourier_improper": {
         "form": "K*(C0+C1*cos(omega)+C2*cos(2*omega))",
@@ -169,7 +180,8 @@ _four_body_functional_forms = {
             "C1": "dimensionless",
             "C2": "dimensionless",
         },
-        "description": "This is a fourier improper"
+        "description": "This is a fourier improper",
+        "canonical_form": "ryckaert_bellemans",
     },
     "harmonic_improper": {
         "form": "K*(chi-chi0)**2",
@@ -178,11 +190,12 @@ _four_body_functional_forms = {
             "K": "[energy]",
             "chi0": "[arcunit]",
         },
-        "description": "This is a harmonic improper"
+        "description": "This is a harmonic improper",
+        "canonical_form": "harmonic_improper",
     },
 }
 
-### Do NOT edit below this line
+# Do NOT edit below this line
 
 four_body_metadata = {}
 
@@ -212,6 +225,13 @@ four_body_metadata["variables"] = {
     }
 }
 
+_inverted_four_body_conversion = dict()
+for k, v in _four_body_functional_forms.items():
+    if v['canonical_form'] in _inverted_four_body_conversion.keys():
+        _inverted_four_body_conversion[v['canonical_form']].append(k)
+    else:
+        _inverted_four_body_conversion[v['canonical_form']] = [k]
+
 # Add store data
 four_body_metadata["store_name"] = "4body"
 four_body_metadata["store_indices"] = {
@@ -224,3 +244,4 @@ four_body_metadata["store_indices"] = {
 
 four_body_metadata["index_columns"] = ["atom1", "atom2", "atom3", "atom4"]
 four_body_metadata["forms"] = _four_body_functional_forms
+four_body_metadata["canonical_form"] = _inverted_four_body_conversion

--- a/eex/metadata/four_body_terms.py
+++ b/eex/metadata/four_body_terms.py
@@ -27,9 +27,9 @@ _four_body_functional_forms = {
             "d": "[arcunit]",
         },
         "description": "This is a charmm dihedral",
-        "canonical_form": "ryckaert_bellemans",
+        "canonical_form": "RB",
     },
-    "multi/harmonic": {
+    "multiharmonic": {
         "form": "A_1 + A_2 * (cos(phi)) + A_3 * (cos(phi)) ** 2 + A_4 * (cos(phi)) ** 3 + A_5 * (cos(phi)) ** (4)",
         "parameters": ["A_1", "A_2", "A_3", "A_4", "A_5"],
         "units": {
@@ -40,9 +40,9 @@ _four_body_functional_forms = {
             "A_5": "[energy]",
         },
         "description": "This is a multi/harmonic dihedral",
-        "canonical_form": "ryckaert_bellemans",
+        "canonical_form": "RB",
     },
-    "ryckaert_bellemans": {
+    "RB": {
         "form": "A_0 + A_1 * (cos(phi)) + A_2 * (cos(phi)) ** 2 + A_3 * (cos(phi)) ** 3 + A_4 * (cos(phi)) ** (4) + A_5 * (cos(phi)) ** (5)",
         "parameters": ["A_0", "A_1", "A_2", "A_3", "A_4", "A_5"],
         "units": {
@@ -55,7 +55,7 @@ _four_body_functional_forms = {
 
         },
         "description": "This is a ryckaert_bellemans",
-        "canonical_form": "ryckaert_bellemans",
+        "canonical_form": "RB",
     },
     # "fourier": {
     #     "form": "Sum(k_i * (1.0 + cos(n_i * phi - d_i)))",
@@ -76,7 +76,7 @@ _four_body_functional_forms = {
             "d": "count"
         },
         "description": "A harmonic dihedral",
-        "canonical_form": "ryckaert_bellemans",
+        "canonical_form": "RB",
     },
     "helix": {
         "form": "A*(1-cos(phi)) + B*(1+cos(3*phi)) + C*(1+cos(phi+PI/4))",
@@ -108,7 +108,7 @@ _four_body_functional_forms = {
             "K_4": "[energy]",
         },
         "description": "This is a opls dihedral",
-        "canonical_form": "ryckaert_bellemans",
+        "canonical_form": "RB",
     },
     "quadratic": {
         "form": "K*(phi-phi0)**2",
@@ -159,7 +159,7 @@ _four_body_functional_forms = {
             "n": "count"
         },
         "description": "This is a cvff improper",
-        "canonical_form": "ryckaert_bellemans",
+        "canonical_form": "RB",
     },
     "distance_improper": {
         "form": "K_2*r**2+K_4*r**4",
@@ -169,7 +169,7 @@ _four_body_functional_forms = {
             "K_4": "[energy] * [length]**4",
         },
         "description": "This is a distance improper",
-        "canonical_form": "ryckaert_bellemans",
+        "canonical_form": "distance_improper",
     },
     "fourier_improper": {
         "form": "K*(C0+C1*cos(omega)+C2*cos(2*omega))",
@@ -181,7 +181,7 @@ _four_body_functional_forms = {
             "C2": "dimensionless",
         },
         "description": "This is a fourier improper",
-        "canonical_form": "ryckaert_bellemans",
+        "canonical_form": "RB",
     },
     "harmonic_improper": {
         "form": "K*(chi-chi0)**2",
@@ -244,4 +244,4 @@ four_body_metadata["store_indices"] = {
 
 four_body_metadata["index_columns"] = ["atom1", "atom2", "atom3", "atom4"]
 four_body_metadata["forms"] = _four_body_functional_forms
-four_body_metadata["canonical_form"] = _inverted_four_body_conversion
+four_body_metadata["group"] = _inverted_four_body_conversion

--- a/eex/metadata/three_body_terms.py
+++ b/eex/metadata/three_body_terms.py
@@ -27,7 +27,8 @@ _three_body_functional_forms = {
             "K": "[energy]",
             "theta0": "[arcunit]"
         },
-        "description": "This is a cosine/squared angle"
+        "description": "This is a cosine/squared angle",
+        "canonical_form": "cosine/squared",
     },
     "cosine": {
         "form": "K*(1+cos(theta))",
@@ -35,7 +36,8 @@ _three_body_functional_forms = {
         "units": {
             "K": "[energy]"
         },
-        "description": "This is a cosine potential"
+        "description": "This is a cosine potential",
+        "canonical_form": "cosine",
     },
     "harmonic": {
         "form": "K * (theta - theta0) ** 2",
@@ -44,7 +46,8 @@ _three_body_functional_forms = {
             "K": "[energy] * [arcunit] ** -2",
             "theta0": "[arcunit]"
         },
-        "description": "A harmonic angle"
+        "description": "A harmonic angle",
+        "canonical_form": "harmonic",
     },
     "cosine/delta": {
         "form": "K*(1+cos(theta-theta0))",
@@ -53,7 +56,8 @@ _three_body_functional_forms = {
             "K": "[energy]",
             "theta0": "[arcunit]"
         },
-        "description": "This is a cosine/delta potential"
+        "description": "This is a cosine/delta potential",
+        "canonical_form": "cosine/delta",
     },
     "charmm": {
         "form": "K*(theta-theta0)**2 + K_ub*(r13-R_ub)**2",
@@ -64,17 +68,19 @@ _three_body_functional_forms = {
             "K_ub": "[energy] * [length] ** -2",
             "R_ub": "[length]",
         },
-        "description": "A CHARMM angle term?"
+        "description": "A CHARMM angle term?",
+        "canonical_form": "charmm",
     },
     "cosine/periodic": {
         "form": "C * (1-B*((-1)**n) * cos(n*theta))",
         "parameters": ["C", "B", "n"],
         "units": {
             "C": "[energy]",
-            "B": "phase",  #1 or -1
+            "B": "phase",  # 1 or -1
             "n": "count"  # 1 2 3 4 5 or 6
         },
-        "description": "This is a cosine/periodic potential"
+        "description": "This is a cosine/periodic potential",
+        "canonical_form": "cosine/periodic",
     },
     "fourier": {
         "form": "K*(c0+c1*cos(theta)+c2*cos(2*theta))",
@@ -85,18 +91,20 @@ _three_body_functional_forms = {
             "c1": "dimensionless",
             "c2": "dimensionless"
         },
-        "description": "This is a fourier potential"
+        "description": "This is a fourier potential",
+        "canonical_form": "fourier",
     },
     "quartic": {
         "form": "K2*(theta-theta0)**2+K3*(theta-theta0)**3+K4*(theta-theta0)**4",
         "parameters": ["K2", "K3", "K4", "theta0"],
         "units": {
-            "K2": "[energy] * [arcunit]**-2",  #Lammps uses radians
+            "K2": "[energy] * [arcunit]**-2",  # Lammps uses radians
             "K3": "[energy] * [arcunit]**-3",
             "K4": "[energy] * [arcunit]**-4",
-            "theta0": "[arcunit]"  #Lammps converts this to radians
+            "theta0": "[arcunit]"  # Lammps converts this to radians
         },
-        "description": "This is a quartic angle"
+        "description": "This is a quartic angle",
+        "canonical_form": "quartic",
     },
     "cosine/shift": {
         "form": "-U_min / 2 * (1 + cos(theta - theta0))",
@@ -105,7 +113,8 @@ _three_body_functional_forms = {
             "U_min": "[energy]",
             "theta0": "[arcunit]"
         },
-        "description": "This is a cosine/shift angle"
+        "description": "This is a cosine/shift angle",
+        "canonical_form": "cosine/shift",
     },
     "fourier/simple": {
         "form": "K*(1 + c*cos(n*theta))",
@@ -115,7 +124,8 @@ _three_body_functional_forms = {
             "c": "dimensionless",
             "n": "phase",
         },
-        "description": "This is a fourier/simple angle"
+        "description": "This is a fourier/simple angle",
+        "canonical_form": "fourier/simple",
     },
     "restricted": {
         "form": "0.5*K*(cos(theta)-cos(theta0))**2/(sin(theta)**2)",
@@ -124,7 +134,8 @@ _three_body_functional_forms = {
             "K": "[energy]",
             "theta0": "radian",
         },
-        "description": "This is a restricted bending angle found in Gromacs"
+        "description": "This is a restricted bending angle found in Gromacs",
+        "canonical_form": "restricted",
     },
     "quartic_gmx": {
         "form": "K0 + K1*(theta-theta0) + K2*(theta-theta0)**2+K3*(theta-theta0)**3+K4*(theta-theta0)**4",
@@ -135,9 +146,10 @@ _three_body_functional_forms = {
             "K2": "[energy] * [arcunit]**-2",
             "K3": "[energy] * [arcunit]**-3",
             "K4": "[energy] * [arcunit]**-4",
-            "theta0": "[arcunit]", 
+            "theta0": "[arcunit]",
         },
-        "description": "This is a quartic angle found in gmx"
+        "description": "This is a quartic angle found in gmx",
+        "canonical_form": "quartic_gmx",
     },
 
     #"class2": {
@@ -181,7 +193,7 @@ _three_body_functional_forms = {
     # },
 }
 
-### Do NOT edit below this line
+# Do NOT edit below this line
 
 three_body_metadata = {}
 
@@ -205,6 +217,13 @@ three_body_metadata["variables"] = {
     },
 }
 
+_inverted_three_body_conversion = dict()
+for k, v in _three_body_functional_forms.items():
+    if v['canonical_form'] in _inverted_three_body_conversion.keys():
+        _inverted_three_body_conversion[v['canonical_form']].append(k)
+    else:
+        _inverted_three_body_conversion[v['canonical_form']] = [k]
+
 # Add store data
 three_body_metadata["store_name"] = "3body"
 three_body_metadata["store_indices"] = {
@@ -216,3 +235,4 @@ three_body_metadata["store_indices"] = {
 
 three_body_metadata["index_columns"] = ["atom1", "atom2", "atom3"]
 three_body_metadata["forms"] = _three_body_functional_forms
+three_body_metadata["group"] = _inverted_three_body_conversion

--- a/eex/metadata/two_body_terms.py
+++ b/eex/metadata/two_body_terms.py
@@ -24,7 +24,8 @@ _two_body_functional_forms = {
             "K3": "[energy] * [length] ** -3",
             "K4": "[energy] * [length] ** -4"
         },
-        "description": "This is a class2 bond"
+        "description": "This is a class2 bond",
+        "canonical_form": "class2",
     },
     "fene": {
         "form": "-0.5*K*R0 ** 2 * log(1-(r/R0) ** 2) + 4*epsilon*((sigma/r) ** 12 - (sigma/r) ** 6) + epsilon",
@@ -35,7 +36,8 @@ _two_body_functional_forms = {
             "epsilon": "[energy]",
             "sigma": "[length]"
         },
-        "description": "This is a fene bond!"
+        "description": "This is a fene bond!",
+        "canonical_form": "fene",
     },
     "fene/expand": {
         "form":
@@ -48,8 +50,8 @@ _two_body_functional_forms = {
             "sigma": "[length]",
             "delta": "[length]"
         },
-        "description":
-        "This is fene/expand bond"
+        "description": "This is fene/expand bond",
+        "canonical_form": "fene/expand",
     },
     "harmonic": {
         "form": "K*(r-R0) ** 2",
@@ -58,7 +60,8 @@ _two_body_functional_forms = {
             "K": "[energy] * [length] ** -2",
             "R0": "[length]"
         },
-        "description": "This is a harmonic bond"
+        "description": "This is a harmonic bond",
+        "canonical_form": "harmonic",
     },
     "morse": {
         "form": "D * (1 - exp(-alpha * (r-R0))) ** 2",
@@ -68,7 +71,8 @@ _two_body_functional_forms = {
             "alpha": "[length] ** -1",
             "R0": "[length]"
         },
-        "description": "This is a class2 bond"
+        "description": "This is a class2 bond",
+        "canonical_form": "morse",
     },
     "nonlinear": {
         "form": "(epsilon * (r - R0) ** 2) / ((lam ** 2) - ((r - R0) ** 2))",
@@ -78,7 +82,8 @@ _two_body_functional_forms = {
             "R0": "[length]",
             "lam": "[length]"
         },
-        "description": "This is a nonlinear bond"
+        "description": "This is a nonlinear bond",
+        "canonical_form": "nonlinear",
     },
     "quartic": {
         "form": "K*(r-Rc) ** 2 * (r-Rc-B1)*(r-Rc-B2) + U0 + 4*epsilon*((sigma/r) ** 12 - (sigma/r) ** 6) + epsilon",
@@ -92,7 +97,8 @@ _two_body_functional_forms = {
             "epsilon": "[energy]",
             "sigma": "[energy]"
         },
-        "description": "This is a quartic bond"
+        "description": "This is a quartic bond",
+        "canonical_form": "quartic",
     },
     "harmonic/shift": {
         "form": "U_min/(R0 - R_c)**2 * ((r - R0) ** 2 - (R_c - R0) ** 2)",
@@ -102,7 +108,8 @@ _two_body_functional_forms = {
             "R0": "[length]",
             "R_c": "[length]"
         },
-        "description": "This is a harmonic/shift bond"
+        "description": "This is a harmonic/shift bond",
+        "canonical_form": "harmonic/shift",
     },
     "oxdna/fene": {
         "form": "-epsilon / 2 * log(1 - ((r - R0) / delta)**2 ) ",
@@ -112,18 +119,20 @@ _two_body_functional_forms = {
             "delta": "[length]",
             "R0": "[length]"
         },
-        "description": "This is a oxdna/fene bond"
+        "description": "This is a oxdna/fene bond",
+        "canonical_form": "oxdna/fene",
     },
-    "fourth_power": {       #Only found in gromacs
+    "fourth_power": {  # Only found in gromacs
         "form": "0.25*K*(r**2 - R0**2)**2",
         "parameters": ["K", "R0"],
         "units": {
             "K": "[energy] [length] ** -4",
             "R0": "[length]"
         },
-        "description": "This is a fourth_power bond. Used in GROMOS force field"
+        "description": "This is a fourth_power bond. Used in GROMOS force field",
+        "canonical_form": "fourth_power",
     },
-    "cubic_bond": {       #Only found in gromacs
+    "cubic_bond": {  # Only found in gromacs
         "form": "K*(r - R0)**2 + K * K_cub * (r-R0)**3",
         "parameters": ["K", "K_cub", "R0"],
         "units": {
@@ -131,17 +140,25 @@ _two_body_functional_forms = {
             "K_cub": "[length] ** -1",
             "R0": "[length]"
         },
-        "description": "This is a cubic_bond potential. Found in GROMACS"
+        "description": "This is a cubic_bond potential. Found in GROMACS",
+        "canonical_form": "cubic_bond",
     },
 }
 
-### Please do not edit below this line
+# Please do not edit below this line
 
 # Internal store name
 two_body_metadata = {}
 
 # Valid variables used in all two-body terms
 two_body_metadata["variables"] = {"r": {"units": "[length]", "description": "Distance between the two indexed atoms."}}
+
+_inverted_two_body_conversion = dict()
+for k, v in _two_body_functional_forms.items():
+    if v['canonical_form'] in _inverted_two_body_conversion.keys():
+        _inverted_two_body_conversion[v['canonical_form']].append(k)
+    else:
+        _inverted_two_body_conversion[v['canonical_form']] = [k]
 
 # Add store data
 two_body_metadata["store_name"] = "2body"
@@ -152,3 +169,4 @@ two_body_metadata["store_indices"] = {
 }
 two_body_metadata["index_columns"] = ["atom1", "atom2"]
 two_body_metadata["forms"] = _two_body_functional_forms
+two_body_metadata["group"] = _inverted_two_body_conversion

--- a/eex/tests/test_dihedral_conv.py
+++ b/eex/tests/test_dihedral_conv.py
@@ -1,0 +1,115 @@
+"""
+Contains tests for the dihedral functional form conversions
+"""
+
+import eex
+import pytest
+import numpy as np
+import pytest
+
+
+def _rb_eval(rb_coeffs):
+    phi = np.linspace(-10, 10, 100)
+    A_0 = rb_coeffs['A_0']
+    A_1 = rb_coeffs['A_1']
+    A_2 = rb_coeffs['A_2']
+    A_3 = rb_coeffs['A_3']
+    A_4 = rb_coeffs['A_4']
+    A_5 = rb_coeffs['A_5']
+    e_rb = A_0 + A_1 * (np.cos(phi)) + A_2 * (np.cos(phi)) ** 2 + A_3 * (np.cos(phi)) ** 3 + A_4 * (np.cos(phi)) ** (4) + A_5 * (np.cos(phi)) ** (5)
+    return e_rb
+
+
+def _opls_eval(opls_coeffs):
+    x = np.linspace(-10, 10, 100)
+    e_opls = 0.5 * (opls_coeffs['K_1'] * (1.0 + np.cos(x))
+                    + opls_coeffs['K_2'] * (1.0 - np.cos(2 * x))
+                    + opls_coeffs['K_3'] * (1.0 + np.cos(3 * x))
+                    + opls_coeffs['K_4'] * (1.0 - np.cos(4 * x)))
+    return e_opls
+
+
+def _charmm_eval(charmm_coeffs):
+    x = np.linspace(-10, 10, 100)
+    e_charmm = np.zeros(len(x))
+    e_charmm += charmm_coeffs["K"] * (1 + np.cos(charmm_coeffs["n"] * x - charmm_coeffs["d"]))
+    return e_charmm
+
+
+@pytest.mark.parametrize("coeffs", [(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+                                    ])
+def test_rb_to_charmm_exceptions(coeffs):
+
+    rb_coeffs = dict()
+
+    for idx, c in enumerate(coeffs):
+        rb_coeffs['A_' + str(idx)] = c
+
+    with pytest.raises(ValueError):
+        charmm_coeffs = eex.dihedral_converter._RB_to_CHARMM(rb_coeffs)
+
+
+@pytest.mark.parametrize("knd", [(0.0, 1.0, np.pi),
+                                 (4.0, 0.0, np.pi),
+                                 (4.0, 0.0, -np.pi),
+                                 (4.0, 6.0, 0.0)])
+def test_charmm_to_rb_exceptions(knd):
+
+    K, n, d = knd
+    charmm_coeffs = {'K': K, 'n': n, 'd': d}
+    with pytest.raises(ValueError):
+        rb_coeffs = eex.dihedral_converter._CHARMM_to_RB(charmm_coeffs)
+
+
+@pytest.mark.parametrize("K", [-4.0, 4.0])
+@pytest.mark.parametrize("n", [1, 2, 3, 4])
+@pytest.mark.parametrize("d", [-np.pi, 0.0, np.pi])
+def test_charmm_to_rb_loop(K, n, d):
+    charmm_coeffs = {'K': K, 'n': n, 'd': d}
+    rb_coeffs = eex.dihedral_converter._CHARMM_to_RB(charmm_coeffs)
+    e_charmm1 = _charmm_eval(charmm_coeffs)
+    e_rb = _rb_eval(rb_coeffs)
+    assert np.allclose(e_charmm1, e_rb)
+    charm_coeffs = eex.dihedral_converter._RB_to_CHARMM(rb_coeffs)
+    e_charmm2 = _charmm_eval(charmm_coeffs)
+    assert np.allclose(e_charmm2, e_rb)
+    assert np.allclose(e_charmm1, e_charmm2)
+
+
+def test_opls_to_rb_loop():
+
+    const = 10.0 * (2 * np.random.random(4) - 1.0)
+    opls_coeffs = {'K_1': const[0], 'K_2': const[1], 'K_3': const[2], 'K_4': const[3]}
+    rb_coeffs = eex.dihedral_converter._OPLS_to_RB(opls_coeffs)
+    e_opls = _opls_eval(opls_coeffs)
+    e_rb = _rb_eval(rb_coeffs)
+    assert np.allclose(e_opls, e_rb)
+    opls_coeffs = eex.dihedral_converter._RB_to_OPLS(rb_coeffs)
+    e_opls = _opls_eval(opls_coeffs)
+    assert np.allclose(e_opls, e_rb)
+
+
+@pytest.mark.parametrize("coeffs", [(0.0, 0.0, 0.0, 0.0),
+                                    ])
+def test_opls_to_rb_exceptions(coeffs):
+
+    opls_coeffs = dict()
+
+    for idx, c in enumerate(coeffs):
+        opls_coeffs['K_' + str(idx + 1)] = c
+
+    with pytest.raises(ValueError):
+        rb_coeffs = eex.dihedral_converter._OPLS_to_RB(opls_coeffs)
+
+
+@pytest.mark.parametrize("coeffs", [(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+                                    ])
+def test_rb_to_opls_exceptions(coeffs):
+
+    rb_coeffs = dict()
+
+    for idx, c in enumerate(coeffs):
+        rb_coeffs['A_' + str(idx)] = c
+
+    with pytest.raises(ValueError):
+        opls_coeffs = eex.dihedral_converter._RB_to_OPLS(rb_coeffs)

--- a/eex/tests/test_dihedral_conv.py
+++ b/eex/tests/test_dihedral_conv.py
@@ -46,7 +46,7 @@ def test_rb_to_charmm_exceptions(coeffs):
         rb_coeffs['A_' + str(idx)] = c
 
     with pytest.raises(ValueError):
-        charmm_coeffs = eex.dihedral_converter._RB_to_CHARMM(rb_coeffs)
+        charmm_coeffs = eex.form_converters.convert_form(4, rb_coeffs, 'RB', 'charmmfsw')
 
 
 @pytest.mark.parametrize("knd", [(0.0, 1.0, np.pi),
@@ -58,7 +58,7 @@ def test_charmm_to_rb_exceptions(knd):
     K, n, d = knd
     charmm_coeffs = {'K': K, 'n': n, 'd': d}
     with pytest.raises(ValueError):
-        rb_coeffs = eex.dihedral_converter._CHARMM_to_RB(charmm_coeffs)
+        rb_coeffs = eex.form_converters.convert_form(4, charmm_coeffs, 'charmmfsw', 'RB')
 
 
 @pytest.mark.parametrize("K", [-4.0, 4.0])
@@ -66,11 +66,11 @@ def test_charmm_to_rb_exceptions(knd):
 @pytest.mark.parametrize("d", [-np.pi, 0.0, np.pi])
 def test_charmm_to_rb_loop(K, n, d):
     charmm_coeffs = {'K': K, 'n': n, 'd': d}
-    rb_coeffs = eex.dihedral_converter._CHARMM_to_RB(charmm_coeffs)
+    rb_coeffs = eex.form_converters.convert_form(4, charmm_coeffs, 'charmmfsw', 'RB')
     e_charmm1 = _charmm_eval(charmm_coeffs)
     e_rb = _rb_eval(rb_coeffs)
     assert np.allclose(e_charmm1, e_rb)
-    charm_coeffs = eex.dihedral_converter._RB_to_CHARMM(rb_coeffs)
+    charm_coeffs = eex.form_converters.convert_form(4, rb_coeffs, 'RB', 'charmmfsw')
     e_charmm2 = _charmm_eval(charmm_coeffs)
     assert np.allclose(e_charmm2, e_rb)
     assert np.allclose(e_charmm1, e_charmm2)
@@ -80,11 +80,11 @@ def test_opls_to_rb_loop():
 
     const = 10.0 * (2 * np.random.random(4) - 1.0)
     opls_coeffs = {'K_1': const[0], 'K_2': const[1], 'K_3': const[2], 'K_4': const[3]}
-    rb_coeffs = eex.dihedral_converter._OPLS_to_RB(opls_coeffs)
+    rb_coeffs = eex.form_converters.convert_form(4, opls_coeffs, 'opls', 'RB')
     e_opls = _opls_eval(opls_coeffs)
     e_rb = _rb_eval(rb_coeffs)
     assert np.allclose(e_opls, e_rb)
-    opls_coeffs = eex.dihedral_converter._RB_to_OPLS(rb_coeffs)
+    opls_coeffs = eex.form_converters.convert_form(4, rb_coeffs, 'RB', 'opls')
     e_opls = _opls_eval(opls_coeffs)
     assert np.allclose(e_opls, e_rb)
 
@@ -99,7 +99,7 @@ def test_opls_to_rb_exceptions(coeffs):
         opls_coeffs['K_' + str(idx + 1)] = c
 
     with pytest.raises(ValueError):
-        rb_coeffs = eex.dihedral_converter._OPLS_to_RB(opls_coeffs)
+        rb_coeffs = eex.form_converters.convert_form(4, opls_coeffs, 'opls', 'RB')
 
 
 @pytest.mark.parametrize("coeffs", [(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
@@ -112,4 +112,4 @@ def test_rb_to_opls_exceptions(coeffs):
         rb_coeffs['A_' + str(idx)] = c
 
     with pytest.raises(ValueError):
-        opls_coeffs = eex.dihedral_converter._RB_to_OPLS(rb_coeffs)
+        opls_coeffs = eex.form_converters.convert_form(4, rb_coeffs, 'RB', 'opls')

--- a/eex/translators/amber/amber_read.py
+++ b/eex/translators/amber/amber_read.py
@@ -184,7 +184,7 @@ def read_amber_file(dl, filename, inpcrd=None, blocksize=5000):
             # Store forcefield parameters as "other" for later processing
             elif current_data_category in amd.store_other and len(data) != 0:
                 df = _data_flatten(data, current_data_category, category_index, "index")
-                
+
                 # Force certain categories to be type int
                 if current_data_category in ["RESIDUE_POINTER", "NUMBER_EXCLUDED_ATOMS", "EXCLUDED_ATOMS_LIST"]:
                     df = df.astype(int)
@@ -215,7 +215,7 @@ def read_amber_file(dl, filename, inpcrd=None, blocksize=5000):
                     _current_topology_indices[category][-1] = np.array([])
 
                 data = data.reshape(-1, mod_size).astype(int)
-                
+
                 # A negative indexed value in position 3 indicates 1-4 NB interactions for this dihedral
                 # should not be counted (multi-term dihedral or cyclic system). Store as
                 # dihedral for now, neglecting negative sign
@@ -366,7 +366,7 @@ def read_amber_file(dl, filename, inpcrd=None, blocksize=5000):
 
     for key, param_data in amd.forcefield_parameters.items():
         param_col_names = list(param_data["column_names"])
-        
+
         # if the needed parameters are stored, this will result in an empty set. If set is not empty, parameters are not
         # stored and do not need to be put in data layer
         if (set(param_col_names) - other_tables):
@@ -451,7 +451,7 @@ def read_amber_file(dl, filename, inpcrd=None, blocksize=5000):
             all_excluded_df = pd.concat([all_excluded_df, excluded_df])
 
         start_index += (row.values[0] + 1)
-    
+
     # Much faster to build large dataframe and add all at once
     if not all_excluded_df.empty:
         dl.set_pair_scalings(all_excluded_df)

--- a/eex/translators/lammps/lammps_ff.py
+++ b/eex/translators/lammps/lammps_ff.py
@@ -3,17 +3,16 @@ Dictionaries for coeff format and units - http://lammps.sandia.gov/doc/Section_c
 """
 
 nb_styles = {
-        "LJ" : {
-            "form": {"name": "LJ", "form": "epsilon/sigma"}, 
-            "parameters": ["epsilon", "sigma"],
-            "units": {
-                "epsilon": "[energy]",
-                "sigma": "[length]",
-            },
-            "description": "This is the classic LJ non-bonded",
-            }
-        }
-
+    "LJ": {
+        "form": {"name": "LJ", "form": "epsilon/sigma"},
+        "parameters": ["epsilon", "sigma"],
+        "units": {
+            "epsilon": "[energy]",
+            "sigma": "[length]",
+        },
+        "description": "This is the classic LJ non-bonded",
+    }
+}
 
 
 bond_styles = {
@@ -222,7 +221,7 @@ angle_styles = {
         "parameters": ["C", "B", "n"],
         "units": {
             "C": "[energy]",
-            "B": "phase",  #1 or -1
+            "B": "phase",  # 1 or -1
             "n": "count"  # 1 2 3 4 5 or 6
         },
         "description": "This is a cosine/periodic potential"
@@ -251,7 +250,7 @@ angle_styles = {
             "K2": "[energy] radian**-2",
             "K3": "[energy] radian**-3",
             "K4": "[energy] radian**-4",
-            "theta0": "degree"  #Lammps converts this to radians
+            "theta0": "degree"  # Lammps converts this to radians
         },
         "description": "This is a quartic bond"
     },
@@ -291,7 +290,7 @@ dihedral_styles = {
     # },
     "charmmfsw": {
         "form": "K*(1 + cos(n*phi-d))",
-        "parameters": ["K","n","d"],
+        "parameters": ["K", "n", "d"],
         "units": {
             "K": "[energy]",
             "n": "count",  # must be type int, no units
@@ -301,12 +300,12 @@ dihedral_styles = {
     },
 
     "multi/harmonic": {
-        "form": "Sum(A_n * (cos(phi))**(n-1))", #n goes from 1 to 5
+        "form": "Sum(A_n * (cos(phi))**(n-1))",  # n goes from 1 to 5
         "parameters": ["A_n"],
         "units": {
-        "A_n": "[energy]",
-         },
-         "description": "This is a multi/harmonic dihedral"
+            "A_n": "[energy]",
+        },
+        "description": "This is a multi/harmonic dihedral"
     },
     # "zero": {
     #     "form": "NYI",
@@ -329,7 +328,7 @@ dihedral_styles = {
     # },
     "fourier": {
         "form": "Sum(k_i * (1.0 + cos(n_i * phi - d_i)))",
-        "parameters": ["k_i","n_i","d_i"],
+        "parameters": ["k_i", "n_i", "d_i"],
         "units": {
             "k_i": "[energy]",
             "n_i": "count",
@@ -339,7 +338,7 @@ dihedral_styles = {
     },
     "harmonic": {
         "form": "K*(1+d*cos(n*phi))",
-        "parameters": ["K","n","d"],
+        "parameters": ["K", "n", "d"],
         "units": {
             "K": "[energy]",
             "n": "count",
@@ -349,7 +348,7 @@ dihedral_styles = {
     },
     "helix": {
         "form": "A*(1-cos(phi)) + B*(1+cos(3*phi)) + C*(1+cos(phi+pi/4))",
-        "parameters": ["A","B","C"],
+        "parameters": ["A", "B", "C"],
         "units": {
             "A": "[energy]",
             "B": "[energy]",
@@ -365,7 +364,7 @@ dihedral_styles = {
     # },
     "nharmonic": {
         "form": "Sum( A_n*(cos(phi))**(n-1))",
-        "parameters": ["A_n","n"],
+        "parameters": ["A_n", "n"],
         "units": {
             "A_n": "[energy]",
             "n": "count"
@@ -374,7 +373,7 @@ dihedral_styles = {
     },
     "opls": {
         "form": "0.5*K_1*(1+cos(phi))+0.5*K_2*(1-cos(2*phi))+0.5*K_3+(1+cos(3*phi))+0.5*K_4*(1-cos(4*phi))",
-        "parameters": ["K_1","K_2","K_3", "K_4"],
+        "parameters": ["K_1", "K_2", "K_3", "K_4"],
         "units": {
             "K_1": "[energy]",
             "K_2": "[energy]",
@@ -385,7 +384,7 @@ dihedral_styles = {
     },
     "quadratic": {
         "form": "K*(phi-phi0)**2",
-        "parameters": ["K","phi0"],
+        "parameters": ["K", "phi0"],
         "units": {
             "K": "[energy] radian ** -2",
             "phi0": "degree"
@@ -462,37 +461,37 @@ improper_styles = {
         },
         "description": "This is a harmonic improper"
     },
-#     "hybrid": {
-#         "form": "NYI",
-#         "parameters": "NYI",
-#         "units": "NYI",
-#         "description": "NYI"
-#     },
-#     "none": {
-#         "form": "NYI",
-#         "parameters": "NYI",
-#         "units": "NYI",
-#         "description": "NYI"
-#     },
-#     "ring": {
-#         "form": "NYI",
-#         "parameters": "NYI",
-#         "units": "NYI",
-#         "description": "NYI"
-#     },
-#     "umbrella":
-#     {  #Used in the dreiding force field
-#         "form": "NYI",
-#         "parameters": "NYI",
-#         "units": "NYI",
-#         "description": "NYI"
-#     },
-#     "zero": {
-#         "form": "NYI",
-#         "parameters": "NYI",
-#         "units": "NYI",
-#         "description": "NYI"
-#     },
+    #     "hybrid": {
+    #         "form": "NYI",
+    #         "parameters": "NYI",
+    #         "units": "NYI",
+    #         "description": "NYI"
+    #     },
+    #     "none": {
+    #         "form": "NYI",
+    #         "parameters": "NYI",
+    #         "units": "NYI",
+    #         "description": "NYI"
+    #     },
+    #     "ring": {
+    #         "form": "NYI",
+    #         "parameters": "NYI",
+    #         "units": "NYI",
+    #         "description": "NYI"
+    #     },
+    #     "umbrella":
+    #     {  #Used in the dreiding force field
+    #         "form": "NYI",
+    #         "parameters": "NYI",
+    #         "units": "NYI",
+    #         "description": "NYI"
+    #     },
+    #     "zero": {
+    #         "form": "NYI",
+    #         "parameters": "NYI",
+    #         "units": "NYI",
+    #         "description": "NYI"
+    #     },
 }
 
 term_data = {}

--- a/eex/translators/lammps/lammps_read.py
+++ b/eex/translators/lammps/lammps_read.py
@@ -18,9 +18,9 @@ def read_lammps_data_file(dl, filename, extra_simulation_data, blocksize=110):
     if not isinstance(extra_simulation_data, dict):
         raise TypeError("Validate term dict: Extra simulation data type '%s' not understood" % str(type(extra_simulation_data)))
 
-    # This is a list of keywords needed from the input file. 
+    # This is a list of keywords needed from the input file.
     # This list depends on the molecule topology (for instance, ethane does
-    # not require 'dihedral_style' information, but butane does. 
+    # not require 'dihedral_style' information, but butane does.
     # More keywords will be appended as required when reader the header
     # section
     # At the very least we need 'units' in the extra_simulation_data dict
@@ -38,8 +38,7 @@ def read_lammps_data_file(dl, filename, extra_simulation_data, blocksize=110):
     startline = None
     current_data_category = None
 
-
-    # Category_list contains keywords of data file e.g. Atoms, Masses, 
+    # Category_list contains keywords of data file e.g. Atoms, Masses,
     # Bond Coeffs, etc.
     category_list = lmd.build_valid_category_list()
 
@@ -55,9 +54,9 @@ def read_lammps_data_file(dl, filename, extra_simulation_data, blocksize=110):
             continue
 
         # Evaluate if line contains any keyword contained in category list. If
-        # True, it means we have read all the required information in the 
+        # True, it means we have read all the required information in the
         # header section. The variable start line is where the header ends
-        # and data begins. At this point, the variable current_data_category 
+        # and data begins. At this point, the variable current_data_category
         # holds the first data section in the data file
         elif eex.utility.fuzzy_list_match(line, category_list)[0]:
             startline = num + 3  # Skips first row and two blank lines
@@ -76,7 +75,7 @@ def read_lammps_data_file(dl, filename, extra_simulation_data, blocksize=110):
             dline = line.split()
             if dline[-1] == "xhi":
                 box_size["x"] = float(dline[1]) - float(dline[0])
-                box_center["x"] = box_size["x"]/2. + float(dline[0])
+                box_center["x"] = box_size["x"] / 2. + float(dline[0])
             elif dline[-1] == "yhi":
                 box_size["y"] = float(dline[1]) - float(dline[0])
                 box_center["y"] = box_size["y"] / 2. + float(dline[0])
@@ -106,9 +105,9 @@ def read_lammps_data_file(dl, filename, extra_simulation_data, blocksize=110):
 
             # If we found keywords such as 'Angle types' that means we need
             # to provide 'Angle style' in the input file (and in the extra
-            # simulation data dictionary). This is important for smaller 
+            # simulation data dictionary). This is important for smaller
             # molecules such as ethane or propane that do not have Angles or
-            # Dihedrals. 
+            # Dihedrals.
 
             if 'types' in size_name and size > 0:
                 needed_keywords.append(size_name.replace('types', 'style').replace(" ", "_"))
@@ -116,8 +115,7 @@ def read_lammps_data_file(dl, filename, extra_simulation_data, blocksize=110):
         else:
             raise IOError("LAMMPS Read: Line not understood!\n%s" % line)
 
-
-    # We have now a list of the needed keywords based on the topology. 
+    # We have now a list of the needed keywords based on the topology.
     # Needed_keywords contains at least ["units"], but can also contain
     # ["units", "bond_style", "angle_style", ...]
     for keyword in needed_keywords:
@@ -142,7 +140,7 @@ def read_lammps_data_file(dl, filename, extra_simulation_data, blocksize=110):
                     raise KeyError("Could not find dihedral style '%s'." % dihedral_style)
             elif keyword == 'atom_style':
                 atom_style = extra_simulation_data['atom_style']
-                if atom_style not in lmd.atom_style: 
+                if atom_style not in lmd.atom_style:
                     raise KeyError("Could not find atom style '%s'." % atom_style)
             else:
                 raise KeyError("Key %s not understood. " % keyword)
@@ -161,16 +159,16 @@ def read_lammps_data_file(dl, filename, extra_simulation_data, blocksize=110):
     if ("atoms" not in list(sizes_dict)) or ("atom types" not in list(sizes_dict)):
         raise IOError("LAMMPS Read: Did not find size data on 'atoms' or 'atom types' in %d header lines." % max_rows)
 
-    # sizes_dict["Pair types"] is relevant if we need to specify 
+    # sizes_dict["Pair types"] is relevant if we need to specify
     # cross interactions explicitly
     sizes_dict["pair types"] = sizes_dict["atom types"] * (sizes_dict["atom types"] + 1) / 2
 
-    # Create temporaries (op_table, term_table), specific to the current unit 
+    # Create temporaries (op_table, term_table), specific to the current unit
     # specification
     # op_table is a dictionary of dictionaries. Its keys are the keywords
     # of the Lammps data file i.e. 'Atoms', 'Bonds', 'Dihedral coeffs', etc.
     # Each key, i.e. Atoms, has a value that is a dictionary. The keys for
-    # these nested dictionaries are 
+    # these nested dictionaries are
     # ['size', 'dl_func', 'df_cols', 'kwargs', 'call_type']
     op_table = lmd.build_operation_table(extra_simulation_data, sizes_dict)
 
@@ -185,11 +183,7 @@ def read_lammps_data_file(dl, filename, extra_simulation_data, blocksize=110):
     # with the desired units
     nb_term_table = lmd.build_nb_table(unit_style)
 
-
-
-
-
-    ### Iterate over the primary data portion of the object
+    # Iterate over the primary data portion of the object
 
     reader = pd.read_table(
         filename,
@@ -261,9 +255,9 @@ def read_lammps_data_file(dl, filename, extra_simulation_data, blocksize=110):
                 for idx, row in data.iterrows():
 
                     op["kwargs"]["nb_parameters"] = row[['epsilon', 'sigma']].to_dict()
-                    if len(uid_list)==1:
+                    if len(uid_list) == 1:
                         op["kwargs"]["atom_type"] = int(row['uid0'])
-                    elif len(uid_list)==2:
+                    elif len(uid_list) == 2:
                         op["kwargs"]["atom_type"] = int(row['uid0'])
                         op["kwargs"]["atom_type2"] = int(row['uid1'])
                     dl.call_by_string(op["dl_func"], **op["kwargs"])
@@ -289,24 +283,40 @@ def read_lammps_data_file(dl, filename, extra_simulation_data, blocksize=110):
     #data["sizes"] = sizes_dict
     #data["header"] = header
 
-    #return data
+    # return data
+
 
 def get_bond_coeff():
     pass
+
+
 def get_angle_coeff():
     pass
+
+
 def get_diherdal_coeff():
     pass
+
+
 def get_include():
     pass
+
+
 def get_variable():
     pass
+
+
 def get_pair_style():
     pass
+
+
 def kspace_style():
     pass
+
+
 def pair_modify():
     pass
+
 
 def read_lammps_input_file(dl, fname, blocksize=110):
     """
@@ -321,7 +331,8 @@ def read_lammps_input_file(dl, fname, blocksize=110):
     input_file = eex.utility.read_lines(fname)
 
     for lnum, line in enumerate(input_file):
-        if len(line) == 0: continue
+        if len(line) == 0:
+            continue
 
         # Handle variables
         if "$" in line:
@@ -331,7 +342,7 @@ def read_lammps_input_file(dl, fname, blocksize=110):
                 variable_values = variable_list[variable_name]["values"]
                 # Need to fix this
                 line = re.sub('\$\{(.*?)\}', variable_values[0], line)
-                
+
             except KeyError:
                 raise KeyError("The variable %s has not been defined" % variable_name)
 
@@ -381,38 +392,38 @@ def read_lammps_input_file(dl, fname, blocksize=110):
 
 def get_special_bonds():
     exclusions = {}
-    special_bonds_keywords = re.findall("[a-zA-Za-z\/]+", " ".join(keyword_opts)) 
+    special_bonds_keywords = re.findall("[a-zA-Za-z\/]+", " ".join(keyword_opts))
     for idx, exclusions_keyword in enumerate(special_bonds_keywords):
         if exclusions_keyword in lmd.exclusions.keys():
             if (exclusions_keyword == 'lj'):
                 exclusions["lj"] = {}
-                exclusions["lj"]["scale12"] = float(keyword_opts[idx+1])
-                exclusions["lj"]["scale13"] = float(keyword_opts[idx+2])
-                exclusions["lj"]["scale14"] = float(keyword_opts[idx+3])
+                exclusions["lj"]["scale12"] = float(keyword_opts[idx + 1])
+                exclusions["lj"]["scale13"] = float(keyword_opts[idx + 2])
+                exclusions["lj"]["scale14"] = float(keyword_opts[idx + 3])
             elif (exclusions_keyword == 'coul'):
                 exclusions["coul"] = {}
-                exclusions["coul"]["scale12"] = float(keyword_opts[idx+1])
-                exclusions["coul"]["scale13"] = float(keyword_opts[idx+2])
-                exclusions["coul"]["scale14"] = float(keyword_opts[idx+3])
+                exclusions["coul"]["scale12"] = float(keyword_opts[idx + 1])
+                exclusions["coul"]["scale13"] = float(keyword_opts[idx + 2])
+                exclusions["coul"]["scale14"] = float(keyword_opts[idx + 3])
             elif (exclusions_keyword == 'lj/coul'):
                 exclusions["lj"] = {}
-                exclusions["lj"]["scale12"] = float(keyword_opts[idx+1])
-                exclusions["lj"]["scale13"] = float(keyword_opts[idx+2])
-                exclusions["lj"]["scale14"] = float(keyword_opts[idx+3])
+                exclusions["lj"]["scale12"] = float(keyword_opts[idx + 1])
+                exclusions["lj"]["scale13"] = float(keyword_opts[idx + 2])
+                exclusions["lj"]["scale14"] = float(keyword_opts[idx + 3])
                 exclusions["coul"] = {}
                 exclusions["coul"]["scale12"] = exclusions["lj"]["scale12"]
                 exclusions["coul"]["scale13"] = exclusions["lj"]["scale13"]
                 exclusions["coul"]["scale14"] = exclusions["lj"]["scale14"]
-            else: 
+            else:
                 exclusions["coul"] = lmd.exclusions[exclusion_keyword]["coul"]
                 exclusions["lj"] = lmd.exclusions[exclusion_keyword]["lj"]
         elif exclusions_keyword in lmd.exclusions["additional_keywords"]:
             raise Exception("Keyword %s is not currently supported", exclusion_keyword)
-    
+
     if "coul" not in exclusions:
         exclusions["coul"] = lmd.exclusions["default"]["coul"]
     if "lj" not in exclusions:
         exclusions["lj"] = lmd.exclusions["default"]["lj"]
-       
+
     return exclusions
     # dl.set_exclusions(exclusions)

--- a/eex/translators/lammps/lammps_write.py
+++ b/eex/translators/lammps/lammps_write.py
@@ -125,7 +125,7 @@ def write_lammps_file(dl, data_filename, input_filename, unit_style="real", bloc
     data.to_csv(data_file, sep=' ', index=False, header=False)
 
     # This is not working in Python 3?
-    #np.savetxt(data_file, np.array(data), fmt='%2d %10.8f')
+    # np.savetxt(data_file, np.array(data), fmt='%2d %10.8f')
 
     data_file.write('\n')
 


### PR DESCRIPTION
This PR adds the necessary functions to perform functional form conversions. It has the following features

- Functions to convert coefficients between functional forms. These are included in bond_converters.py, angle_converters.py, dihedral_converters.py
- A wrapper function that dispatches calls to each of the converters. 
- The wrapper function uses a registry of converter functions that is built via decorating each of the converters.
- Tests for the converters
- Modified the metadata to include a canonical representation of a functional form (in similar fashion of what we currently have with the LJ-AB potential)