### PR TITLE
Pair scalings and interaction order

### DIFF
--- a/eex/datalayer.py
+++ b/eex/datalayer.py
@@ -1189,13 +1189,11 @@ class DataLayer(object):
 
             if not terms.empty:
                 v_col_name = terms.columns.tolist()[-2]
-
                 a1 = terms['atom1'] == atom1_index
-
                 a2 = terms[v_col_name] == atom2_index
 
-            if not terms[a1 & a2].empty:
-                orders = ord
+                if not terms[a1 & a2].empty:
+                    orders = ord
 
         return orders
 

--- a/eex/datalayer.py
+++ b/eex/datalayer.py
@@ -279,9 +279,6 @@ class DataLayer(object):
             raise ValueError("No scaling factors set in set_pair_scalings")
 
         # Check that scalings are type float
-
-        # Determine 'order' of each interaction (if it is bonded will be 2, angle 3, dihedral 4)
-
         # Build multi-level indexer
         index = pd.MultiIndex.from_arrays([scaling_df["atom_index1"], scaling_df["atom_index2"]])
 
@@ -1181,28 +1178,24 @@ class DataLayer(object):
 
         Returns
         --------------------
-            orders: list
+            orders: int
                 Order of atom interaction. None is returned if atom pair is not involved in bond, angle, or dihedral
         """
 
-        # Sanitize order of atom indices
-        if atom2_index < atom1_index:
-            tmp = atom1_index
-            atom_index1 = atom2_index
-            atom_index2 = tmp
+        orders = None
 
-        orders = []
+        for ord in [2, 3, 4]:
+            terms = self.get_terms(ord)
 
-        for o in [2, 3, 4]:
-            terms = self.get_terms(o)
+            if not terms.empty:
+                v_col_name = terms.columns.tolist()[-2]
 
-            v_col_name = [terms.columns[-2]]
+                a1 = terms['atom1'] == atom1_index
 
-            #if not terms.query("atom1 == @atom1_index and @v_col_name == @atom2_index").empty():
-            #    orders.append(o)
+                a2 = terms[v_col_name] == atom2_index
 
-        if orders == []:
-            orders = None
+            if not terms[a1 & a2].empty:
+                orders = ord
 
         return orders
 

--- a/eex/metadata/additional_metadata.py
+++ b/eex/metadata/additional_metadata.py
@@ -170,9 +170,6 @@ exclusions = {
 
 _torsion_convention = ["180_is_trans", "0_is_trans"]
 
-# Column names for nb_scaling dataframe - dl.set_pair_scaling
-nb_scaling = ["atom_index1", "atom_index2", "coul_scale", "vdw_scale"]
-
 nb_scaling = {
             "index": ["atom_index1", "atom_index2"],
             "data" : ["vdw_scale", "coul_scale"],

--- a/eex/metadata/additional_metadata.py
+++ b/eex/metadata/additional_metadata.py
@@ -172,7 +172,8 @@ _torsion_convention = ["180_is_trans", "0_is_trans"]
 
 nb_scaling = {
             "index": ["atom_index1", "atom_index2"],
-            "data" : ["vdw_scale", "coul_scale"],
+            "scaling_type" : ["vdw_scale", "coul_scale"],
+            "data" : ["order"]
             }
 
 #_groups = {

--- a/eex/tests/test_datalayer.py
+++ b/eex/tests/test_datalayer.py
@@ -673,7 +673,7 @@ def test_nb_scaling():
     with pytest.raises(KeyError):
         dl.get_pair_scalings(nb_labels=["not_a_label"])
 
-    stored_scalings = dl.get_pair_scalings()
+    stored_scalings = dl.get_pair_scalings(order=False)
 
     for col in stored_scalings.columns:
         assert set(scale_df[col].values) == set(stored_scalings[col].values)
@@ -744,8 +744,10 @@ def test_set_nb_scaling_factors():
     dl.build_scaling_list()
 
     # Retrieve from datalayer
-    scaling = dl.get_pair_scalings()
+    scaling = dl.get_pair_scalings(nb_labels=["vdw_scale", "coul_scale"], order=True)
 
     assert(set(scaling['vdw_scale'].values) == set([0, 0.5]))
 
     assert(set(scaling['coul_scale'].values) == set([0, 0.25]))
+
+    assert(set(scaling['order'].values) == set([2,3]))

--- a/eex/tests/test_datalayer.py
+++ b/eex/tests/test_datalayer.py
@@ -698,6 +698,9 @@ def test_set_nb_scaling_factors():
 
     dl.add_bonds(bond_df)
 
+    # Check dl.query_atom_pair
+    assert dl.query_atom_pair(1, 2) == 2
+
     # Add an angle
     angle_df = pd.DataFrame()
     angle_data = np.array([[0,1,2,0]])
@@ -707,6 +710,9 @@ def test_set_nb_scaling_factors():
         angle_df[name] = angle_data[:,num]
     
     dl.add_angles(angle_df)
+
+    # Check dl.query_atom_pair
+    assert dl.query_atom_pair(0, 2) == 3
 
     scaling_factors = {
         "coul": {


### PR DESCRIPTION
This PR adds one new function (`query_atom_pair`) to the DL and a new feature to the `get_pair_scalings` function

`query_atom_pairs` returns the term order given two atom ID's (i.e. 2 = bond, 3 = angle, 4 = torsion, or None). 

`get_pair_scalings` uses this added function to add another column (`order`) to the pair scalings data.