### PR TITLE
WIP: Remove terms

### DIFF
--- a/eex/datalayer.py
+++ b/eex/datalayer.py
@@ -1192,7 +1192,6 @@ class DataLayer(object):
         # Figure out atom numbers for this removal.
         # The way this should be done - the index for a particular term to be removed will give the atoms which are involved.
         # All higher order terms which should also be removed if this removal is propagated will involve these atoms.
-        # Use nested list here, where each inner list are atoms for a particular term to be removed.
         atoms = []
 
         if index is not None:

--- a/eex/datalayer.py
+++ b/eex/datalayer.py
@@ -1125,7 +1125,7 @@ class DataLayer(object):
             The order (number of atoms) involved in the expression i.e. 2, "two"
         df : pd.DataFrame
             Adds a DataFrame containing the term information by index
-            Required columns: ["term_index", "atom1_index", ..., "atom(order)_index", "term_index"]
+            Required columns: ["term_index", "atom1_index", ..., "atom(order)_index"]
 
         Returns
         -------
@@ -1161,6 +1161,27 @@ class DataLayer(object):
 
         # Finally store the dataframe
         return self.store.add_table("term" + str(order), df)
+
+    def remove_terms(self, order, index=None):
+        """
+        Removes terms using a index notation.
+
+        Parameters
+        ----------
+        order : {str, int}
+            The order (number of atoms) involved in the expression i.e. 2, "two"
+        index: list
+            The indices of the terms to be removed. If index is None, all terms of that order will be removed.
+
+        Returns
+        -------
+        return : bool
+            Returns a boolean value if the operations was successful or not
+        """
+
+        self.store.remove_table("term" + str(order), index)
+
+        return True
 
     def get_terms(self, order):
         order = metadata.sanitize_term_order_name(order)

--- a/eex/datalayer.py
+++ b/eex/datalayer.py
@@ -1178,8 +1178,26 @@ class DataLayer(object):
         return : bool
             Returns a boolean value if the operations was successful or not
         """
+        order = metadata.sanitize_term_order_name(order)
 
         self.store.remove_table("term" + str(order), index)
+
+        df = self.get_terms(order)
+
+        print(df)
+
+        # Redo term count
+        self._term_count[order] = {}
+        self._term_count[order]["total"] = 0
+
+        uvals, ucnts = np.unique(df["term_index"], return_counts=True)
+        for uval, cnt in zip(uvals, ucnts):
+            if uval not in self._term_count[order]:
+                self._term_count[order][uval] = cnt
+            else:
+                self._term_count[order][uval] += cnt
+
+            self._term_count[order]["total"] += cnt
 
         return True
 

--- a/eex/datalayer.py
+++ b/eex/datalayer.py
@@ -1223,7 +1223,8 @@ class DataLayer(object):
                 # Build list of indices to remove. Should be removed for order if all atoms from 'atoms' are in same row
                 # in dataframe
                 search = terms.isin(atoms).T
-                matching_ind = search.sum()[search.sum()>(o-1)].index.tolist()
+                matching_ind = search.sum()[search.sum()==order].index.tolist()
+
                 remove_index.extend(matching_ind)
 
             # Use FL remove function.

--- a/eex/datalayer.py
+++ b/eex/datalayer.py
@@ -1235,14 +1235,15 @@ class DataLayer(object):
             self._term_count[o] = {}
             self._term_count[o]["total"] = 0
 
-            uvals, ucnts = np.unique(df["term_index"], return_counts=True)
-            for uval, cnt in zip(uvals, ucnts):
-                if uval not in self._term_count[o]:
-                    self._term_count[o][uval] = cnt
-                else:
-                    self._term_count[o][uval] += cnt
+            if not df.empty:
+                uvals, ucnts = np.unique(df["term_index"], return_counts=True)
+                for uval, cnt in zip(uvals, ucnts):
+                    if uval not in self._term_count[o]:
+                        self._term_count[o][uval] = cnt
+                    else:
+                        self._term_count[o][uval] += cnt
 
-                self._term_count[o]["total"] += cnt
+                    self._term_count[o]["total"] += cnt
 
         return True
 

--- a/eex/datalayer.py
+++ b/eex/datalayer.py
@@ -1203,14 +1203,14 @@ class DataLayer(object):
             atoms = atom_df[cols]
 
         # Loop through order to be removed
-        for o in order_list:
+        for ord in order_list:
 
-            # Get column names for order o
-            cols = metadata.get_term_metadata(o, "index_columns")
+            # Get column names for order ord
+            cols = metadata.get_term_metadata(ord, "index_columns")
             cols = [x for x in cols if 'atom' in x]
 
-            # Get terms for order o
-            terms = self.get_terms(o)
+            # Get terms for order ord
+            terms = self.get_terms(ord)
 
             # If atoms list is empty, remove_index = None (ie, all removed). Otherwise, only remove interactions
             # for specified atoms.
@@ -1227,23 +1227,23 @@ class DataLayer(object):
                 remove_index.extend(matching_ind)
 
             # Use FL remove function.
-            self.store.remove_table("term" + str(o), remove_index)
+            self.store.remove_table("term" + str(ord), remove_index)
 
-            df = self.get_terms(o)
+            df = self.get_terms(ord)
 
             # Redo term count
-            self._term_count[o] = {}
-            self._term_count[o]["total"] = 0
+            self._term_count[ord] = {}
+            self._term_count[ord]["total"] = 0
 
             if not df.empty:
                 uvals, ucnts = np.unique(df["term_index"], return_counts=True)
                 for uval, cnt in zip(uvals, ucnts):
-                    if uval not in self._term_count[o]:
-                        self._term_count[o][uval] = cnt
+                    if uval not in self._term_count[ord]:
+                        self._term_count[ord][uval] = cnt
                     else:
-                        self._term_count[o][uval] += cnt
+                        self._term_count[ord][uval] += cnt
 
-                    self._term_count[o]["total"] += cnt
+                    self._term_count[ord]["total"] += cnt
 
         return True
 

--- a/eex/datalayer.py
+++ b/eex/datalayer.py
@@ -1221,10 +1221,10 @@ class DataLayer(object):
 
                 # Build list of indices to remove. Should be removed for order if all atoms from 'atoms' are in same row
                 # in dataframe
-                search = terms.isin(atoms).T
-                matching_ind = search.sum()[search.sum()==order].index.tolist()
-
-                remove_index.extend(matching_ind)
+                for atom_list in atoms.values:
+                    search = terms[cols].isin(atom_list).T
+                    matching_ind = search.sum()[search.sum() == order].index.tolist()
+                    remove_index.extend(matching_ind)
 
             # Use FL remove function.
             self.store.remove_table("term" + str(ord), remove_index)

--- a/eex/filelayer.py
+++ b/eex/filelayer.py
@@ -98,6 +98,22 @@ class HDFStore(BaseStore):
         else:
             return pd.DataFrame()
 
+    def remove_table(self, key, index=None):
+        if key not in self.list_tables():
+            raise KeyError("Key %s does not exist" % key)
+
+        if index is None:
+            # Drop whole table
+            # Remove key from self.tables and self.created_tables
+            self.store.remove(key)
+            self.created_tables.remove(key)
+
+        else:
+            # Drop the subsection of the table. Is there a better way to do this? Arguments for removal are start and
+            # stop, not list of indices
+            for i in index:
+                self.store.remove(key, start=i, stop=i+1)
+
     def close(self):
         """
         Closes the FL file.
@@ -168,7 +184,7 @@ class MemoryStore(BaseStore):
         if key not in list(self.tables):
             raise KeyError("Key %s does not exist" % key)
 
-        if not index:
+        if index is None:
             # Drop whole table
             # Remove key from self.tables and self.table_frags dictionaries
             del self.tables[key]

--- a/eex/filelayer.py
+++ b/eex/filelayer.py
@@ -114,29 +114,19 @@ class HDFStore(BaseStore):
             index.sort()
 
             # Group consectutive indices
-            run = []
-            result = [run]
-            expect = None
+            indices = np.split(index, np.where(np.diff(index) != 1)[0]+1)
 
-            for v in index:
-                if (v == expect) or (expect is None):
-                    run.append(v)
+            ret = []
+            for pair in indices:
+                if pair.shape[0] == 1:
+                    ret.append((pair[0], pair[0] + 1))
                 else:
-                    run = [v]
-                    result.append(run)
-                expect = v + 1
+                    ret.append((pair[0], pair[-1] + 1))
 
-            # Account for row renumbering as rows are removed. Here, a list must be subtracted from a nested list.
-            # Couldn't figure out a way using list comprehension.
-            ind_sub = [0]
-            new_result = []
+            ret.reverse()
 
-            for x in np.arange(len(result)):
-                ind_sub.append(len(result[x]) + ind_sub[-1])
-                new_result.append([y - ind_sub[x] for y in result[x]])
-
-            for i in new_result:
-                self.store.remove(key, start=i[0], stop=i[-1]+1)
+            for i in ret:
+                self.store.remove(key, start=i[0], stop=i[-1])
 
     def close(self):
         """

--- a/eex/filelayer.py
+++ b/eex/filelayer.py
@@ -137,7 +137,6 @@ class MemoryStore(BaseStore):
 
         # Init the base class
         BaseStore.__init__(self, name, store_location, save_data)
-        self.store_filename = os.path.join(self.store_location, self.name + ".h5")
 
         # Table holder dictionary
         self.tables = {}
@@ -164,6 +163,19 @@ class MemoryStore(BaseStore):
             self.table_frags[key] = []
 
         return self.tables[key].copy()
+
+    def remove_table(self, key, index=None):
+        if key not in list(self.tables):
+            raise KeyError("Key %s does not exist" % key)
+
+        if not index:
+            # Drop whole table
+            # Remove key from self.tables and self.table_frags dictionaries
+            del self.tables[key]
+            del self.table_frags[key]
+        else:
+            # Drop the subsection of the table
+            self.tables[key].drop(self.tables[key].index[index])
 
     def close(self):
         """

--- a/eex/filelayer.py
+++ b/eex/filelayer.py
@@ -110,7 +110,10 @@ class HDFStore(BaseStore):
 
         else:
             # Drop the subsection of the table. Is there a better way to do this? Arguments for removal are start and
-            # stop, not list of indices
+            # stop rows, not list of indices
+            index.sort()
+            ind_sub = list(range(len(index)))
+            index = [x - y for x, y in zip(index, ind_sub)]
             for i in index:
                 self.store.remove(key, start=i, stop=i+1)
 

--- a/eex/filelayer.py
+++ b/eex/filelayer.py
@@ -175,7 +175,7 @@ class MemoryStore(BaseStore):
             del self.table_frags[key]
         else:
             # Drop the subsection of the table
-            self.tables[key].drop(self.tables[key].index[index])
+            self.tables[key].drop(self.tables[key].index[index], inplace=True)
 
     def close(self):
         """

--- a/eex/tests/test_datalayer.py
+++ b/eex/tests/test_datalayer.py
@@ -964,6 +964,35 @@ def test_remove_terms_by_index_propogate(butane_dl):
 
     assert (dl.get_term_count(3)['total'] == 1)
 
-    assert(dl.get_term_count)
+    assert(dl.get_term_count(4)['total'] == 0)
+
+    return True
+
+def test_remove_terms_by_index_nonconsecutive_propogate(butane_dl):
+    dl = butane_dl()
+
+    bonds = dl.get_terms(2)
+
+    # Assert topology is what we expect.
+    assert (not bonds.empty)
+
+    #print(dl.get_terms(3))
+
+    assert (dl.get_term_count(2)['total'] == 3)
+
+    assert (dl.get_term_count(3)['total'] == 2)
+
+    assert (dl.get_term_count(4)['total'] == 1)
+
+    # Remove two bonds - choose to propogate this so dihedral and both angles should also be removed.
+    dl.remove_terms(2, index=[0, 2], propogate=True)
+
+    assert(dl.get_term_count(2)['total'] == 1)
+
+    #print(dl.get_terms(3))
+
+    assert (dl.get_term_count(3)['total'] == 0)
+
+    assert(dl.get_term_count(4)['total'] == 0)
 
     return True

--- a/eex/tests/test_datalayer.py
+++ b/eex/tests/test_datalayer.py
@@ -864,16 +864,44 @@ def test_remove_terms_by_index(butane_dl):
 
     dl = butane_dl()
 
-    bonds = dl.get_terms(2)
+    bonds1 = dl.get_terms(2)
 
-    assert(not bonds.empty)
+    assert(not bonds1.empty)
 
     # Remove first two bonds
     dl.remove_terms(2, index=[0,1])
 
-    bonds = dl.get_terms(2)
+    bonds2 = dl.get_terms(2)
 
     assert(dl.get_term_count(2)['total'] == 1)
+
+    # Check that bonds are what we expect
+    assert(sorted(bonds1.loc[2].values) == sorted(bonds2.values[0]))
+
+    # Here, since propogate was set to false. Angles and dihedrals remain unchanged.
+    assert(dl.get_term_count(3)['total'] == 2)
+
+    assert (dl.get_term_count(4)['total'] == 1)
+
+    return True
+
+def test_remove_terms_by_index_nonconsecutive(butane_dl):
+
+    dl = butane_dl()
+
+    bonds1 = dl.get_terms(2)
+
+    assert(not bonds1.empty)
+
+    # Remove two non-consectutive bonds
+    dl.remove_terms(2, index=[0,2])
+
+    bonds2 = dl.get_terms(2)
+
+    assert(dl.get_term_count(2)['total'] == 1)
+
+    # Check that bonds are what we expect
+    assert(sorted(bonds1.loc[1].values) == sorted(bonds2.values[0]))
 
     # Here, since propogate was set to false. Angles and dihedrals remain unchanged.
     assert(dl.get_term_count(3)['total'] == 2)
@@ -899,7 +927,7 @@ def test_remove_terms_propagate(butane_dl):
 
     dl.remove_terms(2, propogate=True)
 
-    # Assert all has been removed.
+    # Assert all have been removed.
     bonds = dl.get_terms(2)
 
     assert(bonds.empty)

--- a/eex/tests/test_datalayer.py
+++ b/eex/tests/test_datalayer.py
@@ -844,3 +844,21 @@ def test_calculate_nb_scaling_factors3(butane_dl):
     with pytest.raises(ValueError):
         dl.calculate_nb_scaling_factors()
 
+def test_remove_terms(butane_dl):
+
+    dl = butane_dl()
+
+    bonds = dl.get_terms(2)
+
+    assert(not bonds.empty)
+
+    dl.remove_terms(2)
+
+    bonds = dl.get_terms(2)
+
+    assert(bonds.empty)
+
+    print(dl.get_term_count(2))
+
+    assert(dl.get_term_count(2)['total'] == 0)
+

--- a/eex/tests/test_datalayer.py
+++ b/eex/tests/test_datalayer.py
@@ -857,7 +857,6 @@ def test_remove_terms(butane_dl):
     bonds = dl.get_terms(2)
 
     assert(bonds.empty)
-
     assert(dl.get_term_count(2)['total'] == 0)
 
 def test_remove_terms_by_index(butane_dl):
@@ -918,11 +917,8 @@ def test_remove_terms_propagate(butane_dl):
 
     # Assert topology is what we expect.
     assert(not bonds.empty)
-
     assert(dl.get_term_count(2)['total'] == 3)
-
     assert(dl.get_term_count(3)['total'] == 2)
-
     assert (dl.get_term_count(4)['total'] == 1)
 
     dl.remove_terms(2, propogate=True)
@@ -931,11 +927,8 @@ def test_remove_terms_propagate(butane_dl):
     bonds = dl.get_terms(2)
 
     assert(bonds.empty)
-
     assert(dl.get_term_count(2)['total'] == 0)
-
     assert(dl.get_term_count(3)['total'] == 0)
-
     assert (dl.get_term_count(4)['total'] == 0)
 
     return True
@@ -948,11 +941,8 @@ def test_remove_terms_by_index_propogate(butane_dl):
 
     # Assert topology is what we expect.
     assert(not bonds.empty)
-
     assert(dl.get_term_count(2)['total'] == 3)
-
     assert(dl.get_term_count(3)['total'] == 2)
-
     assert (dl.get_term_count(4)['total'] == 1)
 
     assert(not bonds.empty)
@@ -961,9 +951,7 @@ def test_remove_terms_by_index_propogate(butane_dl):
     dl.remove_terms(2, index=[0], propogate=True)
 
     assert(dl.get_term_count(2)['total'] == 2)
-
     assert (dl.get_term_count(3)['total'] == 1)
-
     assert(dl.get_term_count(4)['total'] == 0)
 
     return True
@@ -979,20 +967,14 @@ def test_remove_terms_by_index_nonconsecutive_propogate(butane_dl):
     #print(dl.get_terms(3))
 
     assert (dl.get_term_count(2)['total'] == 3)
-
     assert (dl.get_term_count(3)['total'] == 2)
-
     assert (dl.get_term_count(4)['total'] == 1)
 
     # Remove two bonds - choose to propogate this so dihedral and both angles should also be removed.
     dl.remove_terms(2, index=[0, 2], propogate=True)
 
     assert(dl.get_term_count(2)['total'] == 1)
-
-    #print(dl.get_terms(3))
-
     assert (dl.get_term_count(3)['total'] == 0)
-
     assert(dl.get_term_count(4)['total'] == 0)
 
     return True

--- a/eex/tests/test_datalayer.py
+++ b/eex/tests/test_datalayer.py
@@ -918,6 +918,15 @@ def test_remove_terms_by_index_propogate(butane_dl):
 
     bonds = dl.get_terms(2)
 
+    # Assert topology is what we expect.
+    assert(not bonds.empty)
+
+    assert(dl.get_term_count(2)['total'] == 3)
+
+    assert(dl.get_term_count(3)['total'] == 2)
+
+    assert (dl.get_term_count(4)['total'] == 1)
+
     assert(not bonds.empty)
 
     # Remove one bond - choose to propogate this so dihedral and angle should also be removed.
@@ -927,7 +936,6 @@ def test_remove_terms_by_index_propogate(butane_dl):
 
     assert (dl.get_term_count(3)['total'] == 1)
 
-    #assert(dl.get_term_count)
+    assert(dl.get_term_count)
 
     return True
-

--- a/eex/tests/test_datalayer.py
+++ b/eex/tests/test_datalayer.py
@@ -858,7 +858,76 @@ def test_remove_terms(butane_dl):
 
     assert(bonds.empty)
 
-    print(dl.get_term_count(2))
+    assert(dl.get_term_count(2)['total'] == 0)
+
+def test_remove_terms_by_index(butane_dl):
+
+    dl = butane_dl()
+
+    bonds = dl.get_terms(2)
+
+    assert(not bonds.empty)
+
+    # Remove first two bonds
+    dl.remove_terms(2, index=[0,1])
+
+    bonds = dl.get_terms(2)
+
+    assert(dl.get_term_count(2)['total'] == 1)
+
+    # Here, since propogate was set to false. Angles and dihedrals remain unchanged.
+    assert(dl.get_term_count(3)['total'] == 2)
+
+    assert (dl.get_term_count(4)['total'] == 1)
+
+    return True
+
+def test_remove_terms_propagate(butane_dl):
+
+    dl = butane_dl()
+
+    bonds = dl.get_terms(2)
+
+    # Assert topology is what we expect.
+    assert(not bonds.empty)
+
+    assert(dl.get_term_count(2)['total'] == 3)
+
+    assert(dl.get_term_count(3)['total'] == 2)
+
+    assert (dl.get_term_count(4)['total'] == 1)
+
+    dl.remove_terms(2, propogate=True)
+
+    # Assert all has been removed.
+    bonds = dl.get_terms(2)
+
+    assert(bonds.empty)
 
     assert(dl.get_term_count(2)['total'] == 0)
+
+    assert(dl.get_term_count(3)['total'] == 0)
+
+    assert (dl.get_term_count(4)['total'] == 0)
+
+    return True
+
+def test_remove_terms_by_index_propogate(butane_dl):
+
+    dl = butane_dl()
+
+    bonds = dl.get_terms(2)
+
+    assert(not bonds.empty)
+
+    # Remove one bond - choose to propogate this so dihedral and angle should also be removed.
+    dl.remove_terms(2, index=[0], propogate=True)
+
+    assert(dl.get_term_count(2)['total'] == 2)
+
+    assert (dl.get_term_count(3)['total'] == 1)
+
+    #assert(dl.get_term_count)
+
+    return True
 


### PR DESCRIPTION
July 25 - issue with propagating nonconsecutive terms.

Remove terms and term parameters from DL. Will allow editing of topologies and parameters. Goal is to have 'replace' function for functional form conversion. Addition of these functions will allow us to address Issue #25 

This PR contains the following:

1. remove_terms (datalayer)
Function used to remove terms. Calls remove_table in file_layer. Has option to "propagate" term removal, meaning that if a bond is removed, angles and dihedrals containing relevant atoms will also be removed. 

2. remove_table (filelayer - memory backend)
Drops specified terms using pandas drop function with specified indices.

3. remove_table (filelayer - HDF5 backend)
Drops specified terms for HDF5 backend. Indices must be converted to rows for the remove function.

4. Associated tests for functions. 