### PR TITLE
Remove terms

### DIFF
--- a/eex/datalayer.py
+++ b/eex/datalayer.py
@@ -1162,7 +1162,7 @@ class DataLayer(object):
         # Finally store the dataframe
         return self.store.add_table("term" + str(order), df)
 
-    def remove_terms(self, order, index=None, propogate=False):
+    def remove_terms(self, order, index=None, propagate=False):
         """
         Removes terms using a index notation.
 
@@ -1172,7 +1172,7 @@ class DataLayer(object):
             The order (number of atoms) involved in the expression i.e. 2, "two"
         index: list
             The indices of the terms to be removed. If index is None, all terms of that order will be removed.
-        propogate: bool
+        propagate: bool
             This flag indicates if higher order terms should be removed with the removed term.
 
         Returns
@@ -1186,7 +1186,7 @@ class DataLayer(object):
         order_list = [order]
 
         # If this action should be propagated, orders will be added to order list.
-        if propogate == True:
+        if propagate == True:
             order_list.extend([x for x in [3,4] if x > order])
 
         # Figure out atom numbers for this removal.

--- a/eex/datalayer.py
+++ b/eex/datalayer.py
@@ -1224,7 +1224,7 @@ class DataLayer(object):
         order_list = [order]
 
         # If this action should be propagated, orders will be added to order list.
-        if propagate == True:
+        if propagate is True:
             order_list.extend([x for x in [3,4] if x > order])
 
         # Figure out atom numbers for this removal.

--- a/eex/datalayer.py
+++ b/eex/datalayer.py
@@ -1100,11 +1100,11 @@ class DataLayer(object):
             raise KeyError("No terms with order %s exist" % order)
 
         # Check that uid is int and exists in dl.
-        if uid not in list(self._terms[order].keys()):
+        if uid not in self._terms[order]:
             raise KeyError("No terms with order %s and uid %s exist" % (order, uid))
 
         # Check that term count for uid is 0 (shouldn't really be removing if this isn't true)
-        if uid in self.get_term_count(order).keys():
+        if uid in self.get_term_count(order):
             raise ValueError("Terms for order %s and uid %s exist in datalayer. Term parameter cannot be removed" %(order, uid))
 
         # Remove (just delete this key out of _terms dict)

--- a/eex/datalayer.py
+++ b/eex/datalayer.py
@@ -1078,6 +1078,41 @@ class DataLayer(object):
 
         return self._terms[order]
 
+    def remove_term_parameter(self, order, uid):
+        """
+        Removes parameter from datalayer based on term order and uid. This paramater must have a term count of 0.
+
+        Parameters
+        -------------
+        order : int
+            The order of the functional form (2, 3, 4, ...)
+        uid: int
+            The uid of the term to be removed.
+
+
+        Return
+        --------------
+            Returns True if successful
+        """
+
+        # Check that order is int
+        if order not in list(self._terms.keys()):
+            raise KeyError("No terms with order %s exist" % order)
+
+        # Check that uid is int and exists in dl.
+        if uid not in list(self._terms[order].keys()):
+            raise KeyError("No terms with order %s and uid %s exist" % (order, uid))
+
+        # Check that term count for uid is 0 (shouldn't really be removing if this isn't true)
+        if uid in self.get_term_count(order).keys():
+            raise ValueError("Terms for order %s and uid %s exist in datalayer. Term parameter cannot be removed" %(order, uid))
+
+        # Remove (just delete this key out of _terms dict)
+        del self._terms[order][uid]
+
+        return True
+
+
     def list_term_uids(self, order=None):
         """
         Lists all stored UID's in the datalayer.

--- a/eex/datalayer.py
+++ b/eex/datalayer.py
@@ -1095,7 +1095,7 @@ class DataLayer(object):
             Returns True if successful
         """
 
-        # Check that order is int
+        # Check that order exists in datalayer
         if order not in list(self._terms.keys()):
             raise KeyError("No terms with order %s exist" % order)
 
@@ -1216,6 +1216,9 @@ class DataLayer(object):
             Returns a boolean value if the operations was successful or not
         """
         order = metadata.sanitize_term_order_name(order)
+
+        # Check that terms with order exist
+
 
         # Initialize order list
         order_list = [order]

--- a/eex/datalayer.py
+++ b/eex/datalayer.py
@@ -1203,14 +1203,14 @@ class DataLayer(object):
             atoms = atom_df[cols]
 
         # Loop through order to be removed
-        for ord in order_list:
+        for current_order in order_list:
 
             # Get column names for order ord
-            cols = metadata.get_term_metadata(ord, "index_columns")
+            cols = metadata.get_term_metadata(current_order, "index_columns")
             cols = [x for x in cols if 'atom' in x]
 
             # Get terms for order ord
-            terms = self.get_terms(ord)
+            terms = self.get_terms(current_order)
 
             # If atoms list is empty, remove_index = None (ie, all removed). Otherwise, only remove interactions
             # for specified atoms.
@@ -1227,23 +1227,23 @@ class DataLayer(object):
                     remove_index.extend(matching_ind)
 
             # Use FL remove function.
-            self.store.remove_table("term" + str(ord), remove_index)
+            self.store.remove_table("term" + str(current_order), remove_index)
 
-            df = self.get_terms(ord)
+            df = self.get_terms(current_order)
 
             # Redo term count
-            self._term_count[ord] = {}
-            self._term_count[ord]["total"] = 0
+            self._term_count[current_order] = {}
+            self._term_count[current_order]["total"] = 0
 
             if not df.empty:
                 uvals, ucnts = np.unique(df["term_index"], return_counts=True)
                 for uval, cnt in zip(uvals, ucnts):
-                    if uval not in self._term_count[ord]:
-                        self._term_count[ord][uval] = cnt
+                    if uval not in self._term_count[current_order]:
+                        self._term_count[current_order][uval] = cnt
                     else:
-                        self._term_count[ord][uval] += cnt
+                        self._term_count[current_order][uval] += cnt
 
-                    self._term_count[ord]["total"] += cnt
+                    self._term_count[current_order]["total"] += cnt
 
         return True
 

--- a/eex/filelayer.py
+++ b/eex/filelayer.py
@@ -75,7 +75,11 @@ class HDFStore(BaseStore):
             do_append = False
             self.created_tables.append(key)
 
-        data.to_hdf(self.store, key, format="t", append=do_append)
+        if do_append:
+            self.store.append(key, data)
+        else:
+            data.to_hdf(self.store, key, format="t", append=do_append)
+
         return True
 
     def read_table(self, key, rows=None, where=None, chunksize=None):
@@ -127,6 +131,11 @@ class HDFStore(BaseStore):
 
             for i in ret:
                 self.store.remove(key, start=i[0], stop=i[-1])
+
+            # If everything is removed by index, we should drop this key from the list of created tables
+            if self.read_table(key).empty:
+                self.created_tables.remove(key)
+
 
     def close(self):
         """

--- a/eex/tests/test_datalayer.py
+++ b/eex/tests/test_datalayer.py
@@ -978,3 +978,43 @@ def test_remove_terms_by_index_nonconsecutive_propogate(butane_dl):
     assert(dl.get_term_count(4)['total'] == 0)
 
     return True
+
+def test_remove_and_readd_terms(butane_dl):
+    dl = butane_dl()
+
+    bonds = dl.get_terms(2)
+
+    assert(not bonds.empty)
+
+    dl.remove_terms(2)
+
+    bonds_new = dl.get_terms(2)
+
+    assert(bonds_new.empty)
+    assert(dl.get_term_count(2)['total'] == 0)
+
+    dl.add_bonds(bonds)
+
+    added_bonds = dl.get_terms(2)
+
+    assert (not added_bonds.empty)
+
+def test_remove_and_readd_terms_index(butane_dl):
+    dl = butane_dl()
+
+    bonds = dl.get_terms(2)
+
+    assert(not bonds.empty)
+
+    dl.remove_terms(2, index=[0])
+
+    assert(dl.get_term_count(2)['total'] == 2)
+
+    dl.add_bonds(bonds.iloc[[0]])
+
+    added_bonds = dl.get_terms(2)
+
+    assert (not added_bonds.empty)
+
+    for col in added_bonds.columns:
+        assert(set(added_bonds[col].values) == set(bonds[col].values))

--- a/eex/tests/test_datalayer.py
+++ b/eex/tests/test_datalayer.py
@@ -1018,3 +1018,37 @@ def test_remove_and_add_terms_index(butane_dl):
 
     for col in added_bonds.columns:
         assert(set(added_bonds[col].values) == set(bonds[col].values))
+
+def test_remove_term_parameters(butane_dl):
+    dl = butane_dl()
+
+    # First remove angle
+    dl.remove_terms(order=3)
+
+    # Remove angle type from datalayer
+    dl.remove_term_parameter(order=3, uid=0)
+
+    # Assert that there are no stored angle parameters
+    assert not dl.list_term_parameters(order=3)
+
+def test_remove_term_parameters_two(butane_dl):
+    dl = butane_dl()
+
+    # Add second angle
+    uid = dl.add_term_parameter(3, "harmonic", {'K': 62.100, 'theta0': 116},
+                          utype={'K': 'kcal * mol ** -1 * radian ** -2',
+                                 'theta0': 'degree'})
+
+    # First remove angle
+    dl.remove_terms(order=3)
+
+    # Remove angle type from datalayer
+    dl.remove_term_parameter(order=3, uid=0)
+
+    # Add another angle - what will the uid be?
+    uid2 = dl.add_term_parameter(3, "harmonic", {'K': 62.100, 'theta0': 117},
+
+    utype = {'K': 'kcal * mol ** -1 * radian ** -2',
+             'theta0': 'degree'})
+
+    print("The uids are", uid, uid2)

--- a/eex/tests/test_datalayer.py
+++ b/eex/tests/test_datalayer.py
@@ -1022,14 +1022,26 @@ def test_remove_and_add_terms_index(butane_dl):
 def test_remove_term_parameters(butane_dl):
     dl = butane_dl()
 
+    # Check that term parameter cannot be removed if term is not removed first
+    with pytest.raises(ValueError):
+        dl.remove_term_parameter(order=3, uid=0)
+
     # First remove angle
     dl.remove_terms(order=3)
+
+    # Test that this produces error (there is only one term parameter (has uid 0))
+    with pytest.raises(KeyError):
+        dl.remove_term_parameter(order=3, uid=1)
 
     # Remove angle type from datalayer
     dl.remove_term_parameter(order=3, uid=0)
 
     # Assert that there are no stored angle parameters
     assert not dl.list_term_parameters(order=3)
+
+    # Test that second removal produces error
+    with pytest.raises(KeyError):
+        dl.remove_term_parameter(order=3, uid=0)
 
 def test_remove_term_parameters_two(butane_dl):
     dl = butane_dl()

--- a/eex/tests/test_datalayer.py
+++ b/eex/tests/test_datalayer.py
@@ -979,7 +979,7 @@ def test_remove_terms_by_index_nonconsecutive_propogate(butane_dl):
 
     return True
 
-def test_remove_and_readd_terms(butane_dl):
+def test_remove_and_add_terms(butane_dl):
     dl = butane_dl()
 
     bonds = dl.get_terms(2)
@@ -999,7 +999,7 @@ def test_remove_and_readd_terms(butane_dl):
 
     assert (not added_bonds.empty)
 
-def test_remove_and_readd_terms_index(butane_dl):
+def test_remove_and_add_terms_index(butane_dl):
     dl = butane_dl()
 
     bonds = dl.get_terms(2)

--- a/eex/tests/test_datalayer.py
+++ b/eex/tests/test_datalayer.py
@@ -877,7 +877,7 @@ def test_remove_terms_by_index(butane_dl):
     # Check that bonds are what we expect
     assert(sorted(bonds1.loc[2].values) == sorted(bonds2.values[0]))
 
-    # Here, since propogate was set to false. Angles and dihedrals remain unchanged.
+    # Here, since propagate was set to false. Angles and dihedrals remain unchanged.
     assert(dl.get_term_count(3)['total'] == 2)
 
     assert (dl.get_term_count(4)['total'] == 1)
@@ -902,7 +902,7 @@ def test_remove_terms_by_index_nonconsecutive(butane_dl):
     # Check that bonds are what we expect
     assert(sorted(bonds1.loc[1].values) == sorted(bonds2.values[0]))
 
-    # Here, since propogate was set to false. Angles and dihedrals remain unchanged.
+    # Here, since propagate was set to false. Angles and dihedrals remain unchanged.
     assert(dl.get_term_count(3)['total'] == 2)
 
     assert (dl.get_term_count(4)['total'] == 1)
@@ -921,7 +921,7 @@ def test_remove_terms_propagate(butane_dl):
     assert(dl.get_term_count(3)['total'] == 2)
     assert (dl.get_term_count(4)['total'] == 1)
 
-    dl.remove_terms(2, propogate=True)
+    dl.remove_terms(2, propagate=True)
 
     # Assert all have been removed.
     bonds = dl.get_terms(2)
@@ -933,7 +933,7 @@ def test_remove_terms_propagate(butane_dl):
 
     return True
 
-def test_remove_terms_by_index_propogate(butane_dl):
+def test_remove_terms_by_index_propagate(butane_dl):
 
     dl = butane_dl()
 
@@ -947,8 +947,8 @@ def test_remove_terms_by_index_propogate(butane_dl):
 
     assert(not bonds.empty)
 
-    # Remove one bond - choose to propogate this so dihedral and angle should also be removed.
-    dl.remove_terms(2, index=[0], propogate=True)
+    # Remove one bond - choose to propagate this so dihedral and angle should also be removed.
+    dl.remove_terms(2, index=[0], propagate=True)
 
     assert(dl.get_term_count(2)['total'] == 2)
     assert (dl.get_term_count(3)['total'] == 1)
@@ -956,7 +956,7 @@ def test_remove_terms_by_index_propogate(butane_dl):
 
     return True
 
-def test_remove_terms_by_index_nonconsecutive_propogate(butane_dl):
+def test_remove_terms_by_index_nonconsecutive_propagate(butane_dl):
     dl = butane_dl()
 
     bonds = dl.get_terms(2)
@@ -970,8 +970,8 @@ def test_remove_terms_by_index_nonconsecutive_propogate(butane_dl):
     assert (dl.get_term_count(3)['total'] == 2)
     assert (dl.get_term_count(4)['total'] == 1)
 
-    # Remove two bonds - choose to propogate this so dihedral and both angles should also be removed.
-    dl.remove_terms(2, index=[0, 2], propogate=True)
+    # Remove two bonds - choose to propagate this so dihedral and both angles should also be removed.
+    dl.remove_terms(2, index=[0, 2], propagate=True)
 
     assert(dl.get_term_count(2)['total'] == 1)
     assert (dl.get_term_count(3)['total'] == 0)


### PR DESCRIPTION
This PR has two major changes:

- function used for appending to HDF in filelayer is changed. Previously, we used `pd.to_hdf` with the option `append=True`. This had the unexpected (to me) behavior of data not being appended until the file store was closed. The FL now uses the `append` function. This addresses issue #38 

- `remove_term_parameter` function was added to the filelayer, allowing for the removal of term parameters. 

In addition, there are smaller changes like variable renaming and fixing spelling.